### PR TITLE
Fix connecting to replay server & fix "Welcome to RuneScape" detection

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -2102,7 +2102,7 @@ public class ConfigWindow {
     generalPanelClientSizeYSpinner.setValue(
         Settings.CUSTOM_CLIENT_SIZE_Y.get(Settings.currentProfile));
     generalPanelCheckUpdates.setSelected(Settings.CHECK_UPDATES.get(Settings.currentProfile));
-    generalPanelWelcomeEnabled.setSelected(Settings.WELCOME_ENABLED.get(Settings.currentProfile));
+    generalPanelWelcomeEnabled.setSelected(Settings.REMIND_HOW_TO_OPEN_SETTINGS.get(Settings.currentProfile));
     // generalPanelChatHistoryCheckbox.setSelected(Settings.LOAD_CHAT_HISTORY.get(Settings.currentProfile)); // TODO: Implement this feature
     generalPanelCombatXPMenuCheckbox.setSelected(
         Settings.COMBAT_MENU_SHOWN.get(Settings.currentProfile));
@@ -2316,7 +2316,7 @@ public class ConfigWindow {
         Settings.currentProfile,
         ((SpinnerNumberModel) (generalPanelClientSizeYSpinner.getModel())).getNumber().intValue());
     Settings.CHECK_UPDATES.put(Settings.currentProfile, generalPanelCheckUpdates.isSelected());
-    Settings.WELCOME_ENABLED.put(Settings.currentProfile, generalPanelWelcomeEnabled.isSelected());
+    Settings.REMIND_HOW_TO_OPEN_SETTINGS.put(Settings.currentProfile, generalPanelWelcomeEnabled.isSelected());
     // Settings.LOAD_CHAT_HISTORY.put(Settings.currentProfile,
     // generalPanelChatHistoryCheckbox.isSelected());
     Settings.COMBAT_MENU_SHOWN.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -69,7 +69,7 @@ public class Settings {
   public static HashMap<String, Integer> CUSTOM_CLIENT_SIZE_X = new HashMap<String, Integer>();
   public static HashMap<String, Integer> CUSTOM_CLIENT_SIZE_Y = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> CHECK_UPDATES = new HashMap<String, Boolean>();
-  public static HashMap<String, Boolean> WELCOME_ENABLED = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> REMIND_HOW_TO_OPEN_SETTINGS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> LOAD_CHAT_HISTORY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMBAT_MENU_SHOWN = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMBAT_MENU_HIDDEN = new HashMap<String, Boolean>();
@@ -261,14 +261,14 @@ public class Settings {
     CHECK_UPDATES.put(
         "custom", getPropBoolean(props, "check_updates", CHECK_UPDATES.get("default")));
 
-    WELCOME_ENABLED.put("vanilla", false);
-    WELCOME_ENABLED.put("vanilla_resizable", false);
-    WELCOME_ENABLED.put("lite", false);
-    WELCOME_ENABLED.put("default", true);
-    WELCOME_ENABLED.put("heavy", true);
-    WELCOME_ENABLED.put("all", true);
-    WELCOME_ENABLED.put(
-        "custom", getPropBoolean(props, "welcome_enabled", WELCOME_ENABLED.get("default")));
+    REMIND_HOW_TO_OPEN_SETTINGS.put("vanilla", false);
+    REMIND_HOW_TO_OPEN_SETTINGS.put("vanilla_resizable", false);
+    REMIND_HOW_TO_OPEN_SETTINGS.put("lite", false);
+    REMIND_HOW_TO_OPEN_SETTINGS.put("default", true);
+    REMIND_HOW_TO_OPEN_SETTINGS.put("heavy", true);
+    REMIND_HOW_TO_OPEN_SETTINGS.put("all", true);
+    REMIND_HOW_TO_OPEN_SETTINGS.put(
+        "custom", getPropBoolean(props, "welcome_enabled", REMIND_HOW_TO_OPEN_SETTINGS.get("default")));
 
     LOAD_CHAT_HISTORY.put("vanilla", false);
     LOAD_CHAT_HISTORY.put("vanilla_resizable", false);
@@ -1456,7 +1456,7 @@ public class Settings {
       props.setProperty("custom_client_size_x", Integer.toString(CUSTOM_CLIENT_SIZE_X.get(preset)));
       props.setProperty("custom_client_size_y", Integer.toString(CUSTOM_CLIENT_SIZE_Y.get(preset)));
       props.setProperty("check_updates", Boolean.toString(CHECK_UPDATES.get(preset)));
-      props.setProperty("welcome_enabled", Boolean.toString(WELCOME_ENABLED.get(preset)));
+      props.setProperty("welcome_enabled", Boolean.toString(REMIND_HOW_TO_OPEN_SETTINGS.get(preset)));
       props.setProperty("load_chat_history", Boolean.toString(LOAD_CHAT_HISTORY.get(preset)));
       props.setProperty("combat_menu", Boolean.toString(COMBAT_MENU_SHOWN.get(preset)));
       props.setProperty("combat_menu_hidden", Boolean.toString(COMBAT_MENU_HIDDEN.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -701,6 +701,45 @@ public class Client {
     }
   }
 
+  // triggered on receiving Welcome screen; opcode 182
+  public static void allTheWayLoggedIn() {
+    if (Settings.FIRST_TIME.get(Settings.currentProfile)) {
+      Settings.FIRST_TIME.put(Settings.currentProfile, false);
+      Settings.save();
+    }
+
+    // Get keybind to open the config window so that we can tell the player how to open it
+    if (Settings.WELCOME_ENABLED.get(Settings.currentProfile)) {
+      String configWindowShortcut = "";
+      for (KeybindSet kbs : KeyboardHandler.keybindSetList) {
+        if ("show_config_window".equals(kbs.getCommandName())) {
+          configWindowShortcut = kbs.getFormattedKeybindText();
+          break;
+        }
+      }
+      if ("".equals(configWindowShortcut)) {
+        Logger.Error("Could not find the keybind for the config window!");
+        configWindowShortcut = "<Keybind error>";
+      }
+
+      displayMessage("@mag@Type @yel@::help@mag@ for a list of commands", CHAT_QUEST);
+      displayMessage("@mag@Open the settings with @yel@"
+              + configWindowShortcut
+              + "@mag@ or @yel@right-click the tray icon",
+          CHAT_QUEST);
+    }
+
+    if (TwitchIRC.isUsing()) twitch.connect();
+
+    // Check for updates every login at most once per hour,
+    // so users are notified when an update is available
+    long currentTime = System.currentTimeMillis();
+    if (Settings.CHECK_UPDATES.get(Settings.currentProfile) && currentTime >= updateTimer) {
+      checkForUpdate(false);
+      updateTimer = currentTime + (60 * 60 * 1000);
+    }
+  }
+
   public static void disconnect_hook() {
     // ::lostcon or closeConnection
     Replay.closeReplayRecording();
@@ -1657,45 +1696,6 @@ public class Client {
 
     if (type == Client.CHAT_PRIVATE || type == Client.CHAT_PRIVATE_OUTGOING) {
       if (username != null) lastpm_username = username;
-    }
-
-    if (message.startsWith("Welcome to RuneScape!")
-        && Settings.WELCOME_ENABLED.get(Settings.currentProfile)) {
-      // because this section of code is triggered when the "Welcome to RuneScape!" message first
-      // appears, we can use it to do some first time set up
-      if (Settings.FIRST_TIME.get(Settings.currentProfile)) {
-        Settings.FIRST_TIME.put(Settings.currentProfile, false);
-        Settings.save();
-      }
-
-      // Get keybind to open the config window
-      String configWindowShortcut = "";
-      for (KeybindSet kbs : KeyboardHandler.keybindSetList) {
-        if ("show_config_window".equals(kbs.getCommandName())) {
-          configWindowShortcut = kbs.getFormattedKeybindText();
-          break;
-        }
-      }
-      if ("".equals(configWindowShortcut)) {
-        Logger.Error("Could not find the keybind for the config window!");
-        configWindowShortcut = "<Keybind error>";
-      }
-
-      // TODO: possibly put this in welcome screen or at least _after_ "Welcome to RuneScape"
-      displayMessage("@mag@Type @yel@::help@mag@ for a list of commands", CHAT_QUEST);
-      displayMessage(
-          "@mag@Open the settings with @yel@"
-              + configWindowShortcut
-              + "@mag@ or @yel@right-click the tray icon",
-          CHAT_QUEST);
-
-      // Check for updates every login in hour intervals, so users are notified when an update is
-      // available
-      long currentTime = System.currentTimeMillis();
-      if (Settings.CHECK_UPDATES.get(Settings.currentProfile) && currentTime >= updateTimer) {
-        checkForUpdate(false);
-        updateTimer = currentTime + (60 * 60 * 1000);
-      }
     }
 
     // Don't output private messages if option is turned on and replaying

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -709,7 +709,7 @@ public class Client {
     }
 
     // Get keybind to open the config window so that we can tell the player how to open it
-    if (Settings.WELCOME_ENABLED.get(Settings.currentProfile)) {
+    if (Settings.REMIND_HOW_TO_OPEN_SETTINGS.get(Settings.currentProfile)) {
       String configWindowShortcut = "";
       for (KeybindSet kbs : KeyboardHandler.keybindSetList) {
         if ("show_config_window".equals(kbs.getCommandName())) {

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1153,6 +1153,16 @@ public class Replay {
         output_checksum.update(buffer.array());
         output.write(buffer.array());
         output.flush();
+
+        /*
+         // Debug viewing entire output stream
+        System.out.print("Writing Output Stream: ");
+        for (byte h : buffer.array()) {
+            System.out.print(String.format("%d ",  Byte.toUnsignedInt(h)));
+        }
+        System.out.println();
+        */
+
         return;
       }
 
@@ -1163,6 +1173,16 @@ public class Replay {
       output_checksum.update(buffer.array());
       output.write(buffer.array());
       output.flush();
+
+      /*
+      // Debug viewing entire output stream
+      System.out.print("Writing Output Stream: ");
+      for (byte h : buffer.array()) {
+        System.out.print(String.format("%d ",  Byte.toUnsignedInt(h)));
+      }
+      System.out.println();
+      */
+
     } catch (Exception e) {
       e.printStackTrace();
       shutdown_error();

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1232,12 +1232,14 @@ public class Replay {
   }
 
   public static void checkPoint(int opcode, int len) {
-    if (input == null) return;
+    if (opcode == 182) { // SERVER_OPCODE_SHOW_WELCOME
 
-    if (isRecording) {
-      // received packet 182, set flag, do not dump bytes
-      // Logger.Debug(String.format("Decrypted opcode: %d", opcode)); // Debug Info
-      if (opcode == 182) {
+      // getting opcode 182, we can tell that player very recently managed to log in successfully.
+      Client.allTheWayLoggedIn();
+
+      // received packet 182 while recording, set flag, do not dump bytes
+      if (input == null) return;
+      if (isRecording) {
         // in here probably would need to check the position
         // don't care about the packet if 182, just rewrite it using the enc opcode
         try {

--- a/src/Game/ReplayServer.java
+++ b/src/Game/ReplayServer.java
@@ -160,9 +160,7 @@ public class ReplayServer implements Runnable {
       sock = ServerSocketChannel.open();
       // last attempt 10 + default port
       usePort = port == -1 ? Replay.DEFAULT_PORT + 10 : port;
-      if (usePort != Replay.DEFAULT_PORT) {
-        Replay.changePort(usePort);
-      }
+      Replay.changePort(usePort);
       sock.bind(new InetSocketAddress(usePort));
 
       // Let's connect our client


### PR DESCRIPTION
There was a problem with connecting to the replay server if a World was defined with a nonstandard port. The original code did not expect the port to change unless it told it to, causing the client to be unable to connect and hang.

---

Also, I have moved detection of being "all the way logged in" from the message hook that looks for the string "Welcome to RuneScape" to a place that I had always intended for "player is all the way logged in" to be detected: off of opcode 182 SHOW_WELCOME_SCREEN.

This is superior for 3 reasons:
1. I was always annoyed that "Welcome to RuneScape" was no longer the first message displayed to the client. This commit resolves a 4 year old TODO to figure out a way to put custom logic UNDER that message.
2. "Welcome to RuneScape" is an unsuitable detection for if the player has recently logged in. The text also appears when undergoing a Make-over-Mage transformation.
3. On some private servers, the text "Welcome to RuneScape" does not appear at all.

182 SHOW_WELCOME_SCREEN always appears exactly one time and only at login. It happens slightly after the "Welcome to RuneScape" message, which is ideal.