### PR TITLE
Speedrunner mode & fix Twitch Chat integration

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -217,11 +217,14 @@ public class ConfigWindow {
 
   //// Streaming & Privacy tab
   private JCheckBox streamingPanelTwitchChatCheckbox;
+  private JCheckBox streamingPanelTwitchChatIntegrationEnabledCheckbox;
   private JTextField streamingPanelTwitchChannelNameTextField;
   private JTextField streamingPanelTwitchOAuthTextField;
   private JTextField streamingPanelTwitchUserTextField;
   private JCheckBox streamingPanelIPAtLoginCheckbox;
   private JCheckBox streamingPanelSaveLoginCheckbox;
+  private JCheckBox streamingPanelSpeedrunnerCheckbox;
+  // private JTextField streamingPanelSpeedrunnerUsernameTextField;
 
   //// Replay tab
   private JCheckBox replayPanelRecordKBMouseCheckbox;
@@ -1204,6 +1207,11 @@ public class ConfigWindow {
 
     addSettingsHeader(streamingPanel, "Streaming & Privacy");
 
+    streamingPanelTwitchChatIntegrationEnabledCheckbox = addCheckbox("Enable Twitch chat integration", streamingPanel);
+    streamingPanelTwitchChatIntegrationEnabledCheckbox.setToolTipText(
+        "If this box is checked, and the 3 relevant text fields are filled out, you will connect to a chat channel on login.");
+    streamingPanelTwitchChatIntegrationEnabledCheckbox.setBorder(new EmptyBorder(2, 0, 9, 0));
+
     streamingPanelTwitchChatCheckbox = addCheckbox("Hide incoming Twitch chat", streamingPanel);
     streamingPanelTwitchChatCheckbox.setToolTipText(
         "Don't show chat from other Twitch users, but still be able to send Twitch chat");
@@ -1216,9 +1224,9 @@ public class ConfigWindow {
     streamingPanelTwitchChannelNamePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     streamingPanelTwitchChannelNamePanel.setBorder(new EmptyBorder(0, 0, 9, 0));
 
-    JLabel streamingPanelTwitchChannelNameLabel = new JLabel("Twitch channel name: ");
+    JLabel streamingPanelTwitchChannelNameLabel = new JLabel("Twitch channel to chat in: ");
     streamingPanelTwitchChannelNameLabel.setToolTipText(
-        "The Twitch channel you want to chat in (leave empty to stop trying to connect to Twitch)");
+        "The Twitch channel you want to chat in");
     streamingPanelTwitchChannelNamePanel.add(streamingPanelTwitchChannelNameLabel);
     streamingPanelTwitchChannelNameLabel.setAlignmentY((float) 0.9);
 
@@ -1236,7 +1244,7 @@ public class ConfigWindow {
     streamingPanelTwitchUserPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     streamingPanelTwitchUserPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
 
-    JLabel streamingPanelTwitchUserLabel = new JLabel("Twitch username: ");
+    JLabel streamingPanelTwitchUserLabel = new JLabel("Your Twitch username: ");
     streamingPanelTwitchUserLabel.setToolTipText("The Twitch username you log into Twitch with");
     streamingPanelTwitchUserPanel.add(streamingPanelTwitchUserLabel);
     streamingPanelTwitchUserLabel.setAlignmentY((float) 0.9);
@@ -1255,7 +1263,7 @@ public class ConfigWindow {
     streamingPanelTwitchOAuthPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     streamingPanelTwitchOAuthPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
 
-    JLabel streamingPanelTwitchOAuthLabel = new JLabel("Twitch OAuth token: ");
+    JLabel streamingPanelTwitchOAuthLabel = new JLabel("Your Twitch OAuth token (not your Stream key): ");
     streamingPanelTwitchOAuthLabel.setToolTipText("Your Twitch OAuth token (not your Stream Key)");
     streamingPanelTwitchOAuthPanel.add(streamingPanelTwitchOAuthLabel);
     streamingPanelTwitchOAuthLabel.setAlignmentY((float) 0.9);
@@ -1275,6 +1283,44 @@ public class ConfigWindow {
         addCheckbox("Save login information between logins (Requires restart)", streamingPanel);
     streamingPanelSaveLoginCheckbox.setToolTipText(
         "Preserves login details between logins (Disable this if you're streaming)");
+
+    JLabel spacerLabel =
+        new JLabel("<html><head><style>p{font-size:10px;}</style></head><p>&nbsp;</p>");
+    streamingPanel.add(spacerLabel);
+
+    addSettingsHeader(streamingPanel, "Speedrunner Mode");
+    JLabel speedrunnerModeExplanation =
+        new JLabel("<html><head><style>p{font-size:10px;}ul{padding-left:0px;margin-left:10px;}</style></head><p>Speedrunner mode keeps track of your precise time spent in game <br/> between the first player update packet received and either logout or<br/> upon completing any of the following goals:<br/><ul><li>Completion of Tutorial Island</li><li>Completion of Black Knight's Fortress</li><li>Entrance to the Champion's Guild</li><li>Completion of Dragon Slayer</li></ul></p><p>Speedrunner mode also overrides the following RSC+ options:<ul><li>You will always be recording a replay</li><li>You will not be able to desync the camera position from the player position (too weird)</li><li>Keyboard shortcut to trigger sleeping bag is disabled</li><li>Menu item swapping (e.g. \"Always left click to attack\") is disabled <ul style=\"padding:0px; margin: 2px 0 0 10px;\"><li style=\"padding:0px; margin:0px;\">REQUIRES RESTART IF NOT ALREADY DISABLED</li></ul></li></ul></p><p>The below box should be manually clicked before logging in to a new character.<br/> The apply button must be clicked for it to take effect.</p><br/></html>");
+    speedrunnerModeExplanation.setBorder(new EmptyBorder(2, 0, 0, 0));
+    streamingPanel.add(speedrunnerModeExplanation);
+
+    streamingPanelSpeedrunnerCheckbox = addCheckbox("Activate Speedrunner Mode", streamingPanel);
+    streamingPanelSpeedrunnerCheckbox.setToolTipText("Speedrunner Mode, see above explanation");
+
+    JLabel speedrunnerHowToSTOPSPEEDRUNNINGGGGExplanation =
+        new JLabel("<html><head><style>p{font-size:10px; padding-bottom: 5px;}</style></head><p>When you are satisfied that your run is over, end the speedrun<br/> by sending the command <font face=\"courier\"><strong>::endrun</strong></font> or press the configurable keybind <strong>&lt;CTRL-END&gt;</strong>.</p></html>");
+    streamingPanel.add(speedrunnerHowToSTOPSPEEDRUNNINGGGGExplanation);
+
+    /* shame to write all this code and then not need it...
+    JPanel streamingPanelSpeedRunnerNamePanel = new JPanel();
+    streamingPanel.add(streamingPanelSpeedRunnerNamePanel);
+    streamingPanelSpeedRunnerNamePanel.setLayout(
+        new BoxLayout(streamingPanelSpeedRunnerNamePanel, BoxLayout.X_AXIS));
+    streamingPanelSpeedRunnerNamePanel.setPreferredSize(new Dimension(0, 37));
+    streamingPanelSpeedRunnerNamePanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    streamingPanelSpeedRunnerNamePanel.setBorder(new EmptyBorder(0, 0, 9, 0));
+
+    JLabel streamingPanelSpeedRunnerUsernameLabel = new JLabel("Speedrunner username: ");
+    streamingPanelSpeedRunnerUsernameLabel.setToolTipText("Only apply speedrunner restrictions/enhancements if the username in this field matches.");
+    streamingPanelSpeedRunnerNamePanel.add(streamingPanelSpeedRunnerUsernameLabel);
+    streamingPanelSpeedRunnerUsernameLabel.setAlignmentY((float) 0.9);
+
+    streamingPanelSpeedrunnerUsernameTextField = new JTextField();
+    streamingPanelSpeedRunnerNamePanel.add(streamingPanelSpeedrunnerUsernameTextField);
+    streamingPanelSpeedrunnerUsernameTextField.setMaximumSize(new Dimension(Short.MAX_VALUE, 28));
+    streamingPanelSpeedrunnerUsernameTextField.setMinimumSize(new Dimension(100, 28));
+    streamingPanelSpeedrunnerUsernameTextField.setAlignmentY((float) 0.75);
+    */
 
     /*
      * Keybind tab
@@ -1470,6 +1516,12 @@ public class ConfigWindow {
         "toggle_ipdns",
         KeyModifier.CTRL,
         KeyEvent.VK_J);
+    addKeybindSet(
+        keybindContainerPanel,
+        "End your current speedrun",
+        "endrun",
+        KeyModifier.CTRL,
+        KeyEvent.VK_END);
     // TODO: Uncomment the following line if this feature no longer requires a restart
     // addKeybindSet(keybindContainerPanel, "Toggle save login information",
     // "toggle_save_login_info",
@@ -2259,6 +2311,8 @@ public class ConfigWindow {
         Settings.SOUND_NOTIFS_ALWAYS.get(Settings.currentProfile));
 
     // Streaming & Privacy tab
+    streamingPanelTwitchChatIntegrationEnabledCheckbox.setSelected(
+        Settings.TWITCH_CHAT_ENABLED.get(Settings.currentProfile));
     streamingPanelTwitchChatCheckbox.setSelected(
         Settings.TWITCH_HIDE_CHAT.get(Settings.currentProfile));
     streamingPanelTwitchChannelNameTextField.setText(
@@ -2270,6 +2324,9 @@ public class ConfigWindow {
         Settings.SHOW_LOGIN_IP_ADDRESS.get(Settings.currentProfile));
     streamingPanelSaveLoginCheckbox.setSelected(
         Settings.SAVE_LOGININFO.get(Settings.currentProfile));
+    streamingPanelSpeedrunnerCheckbox.setSelected(
+        Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile));
+    //streamingPanelSpeedrunnerUsernameTextField.setText(Settings.SPEEDRUNNER_USERNAME.get(Settings.currentProfile));
 
     // Replay tab
     replayPanelRecordAutomaticallyCheckbox.setSelected(
@@ -2454,6 +2511,8 @@ public class ConfigWindow {
         Settings.currentProfile, notificationPanelNotifSoundAnyFocusButton.isSelected());
 
     // Streaming & Privacy
+    Settings.TWITCH_CHAT_ENABLED.put(
+        Settings.currentProfile, streamingPanelTwitchChatIntegrationEnabledCheckbox.isSelected());
     Settings.TWITCH_HIDE_CHAT.put(
         Settings.currentProfile, streamingPanelTwitchChatCheckbox.isSelected());
     Settings.TWITCH_CHANNEL.put(
@@ -2466,6 +2525,10 @@ public class ConfigWindow {
         Settings.currentProfile, streamingPanelIPAtLoginCheckbox.isSelected());
     Settings.SAVE_LOGININFO.put(
         Settings.currentProfile, streamingPanelSaveLoginCheckbox.isSelected());
+    Settings.SPEEDRUNNER_MODE_ACTIVE.put(
+        Settings.currentProfile, streamingPanelSpeedrunnerCheckbox.isSelected());
+    //Settings.SPEEDRUNNER_USERNAME.put(
+    //    Settings.currentProfile, streamingPanelSpeedrunnerUsernameTextField.getText());
 
     // Replay
     Settings.RECORD_AUTOMATICALLY.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -148,12 +148,15 @@ public class Settings {
   public static HashMap<String, Integer> FATIGUE_NOTIF_VALUE = new HashMap<String, Integer>();
 
   //// streaming
+  public static HashMap<String, Boolean> TWITCH_CHAT_ENABLED = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> TWITCH_HIDE_CHAT = new HashMap<String, Boolean>();
   public static HashMap<String, String> TWITCH_CHANNEL = new HashMap<String, String>();
   public static HashMap<String, String> TWITCH_OAUTH = new HashMap<String, String>();
   public static HashMap<String, String> TWITCH_USERNAME = new HashMap<String, String>();
   public static HashMap<String, Boolean> SHOW_LOGIN_IP_ADDRESS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SAVE_LOGININFO = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SPEEDRUNNER_MODE_ACTIVE = new HashMap<String, Boolean>();
+  // public static HashMap<String, String> SPEEDRUNNER_USERNAME = new HashMap<String, String>();
 
   //// replay
   public static HashMap<String, Boolean> RECORD_KB_MOUSE = new HashMap<String, Boolean>();
@@ -902,6 +905,15 @@ public class Settings {
         "custom", getPropInt(props, "fatigue_notif_value", FATIGUE_NOTIF_VALUE.get("default")));
 
     //// streaming
+    TWITCH_CHAT_ENABLED.put("vanilla", false);
+    TWITCH_CHAT_ENABLED.put("vanilla_resizable", false);
+    TWITCH_CHAT_ENABLED.put("lite", true);
+    TWITCH_CHAT_ENABLED.put("default", true);
+    TWITCH_CHAT_ENABLED.put("heavy", true);
+    TWITCH_CHAT_ENABLED.put("all", true);
+    TWITCH_CHAT_ENABLED.put(
+        "custom", getPropBoolean(props, "twitch_enabled", TWITCH_CHAT_ENABLED.get("default")));
+
     TWITCH_HIDE_CHAT.put("vanilla", true);
     TWITCH_HIDE_CHAT.put("vanilla_resizable", true);
     TWITCH_HIDE_CHAT.put("lite", false);
@@ -954,6 +966,26 @@ public class Settings {
     SAVE_LOGININFO.put("all", true);
     SAVE_LOGININFO.put(
         "custom", getPropBoolean(props, "save_logininfo", SAVE_LOGININFO.get("default")));
+
+    SPEEDRUNNER_MODE_ACTIVE.put("vanilla", false);
+    SPEEDRUNNER_MODE_ACTIVE.put("vanilla_resizable", false);
+    SPEEDRUNNER_MODE_ACTIVE.put("lite", false);
+    SPEEDRUNNER_MODE_ACTIVE.put("default", false);
+    SPEEDRUNNER_MODE_ACTIVE.put("heavy", false);
+    SPEEDRUNNER_MODE_ACTIVE.put("all", true);
+    SPEEDRUNNER_MODE_ACTIVE.put(
+        "custom", getPropBoolean(props, "speedrun_active", SPEEDRUNNER_MODE_ACTIVE.get("default")));
+
+    /*
+    SPEEDRUNNER_USERNAME.put("vanilla", "");
+    SPEEDRUNNER_USERNAME.put("vanilla_resizable", "");
+    SPEEDRUNNER_USERNAME.put("lite", "");
+    SPEEDRUNNER_USERNAME.put("default", "");
+    SPEEDRUNNER_USERNAME.put("heavy", "");
+    SPEEDRUNNER_USERNAME.put("all", "");
+    SPEEDRUNNER_USERNAME.put(
+        "custom", getPropString(props, "speedrun_username", SPEEDRUNNER_USERNAME.get("default")));
+        */
 
     //// replay
     RECORD_KB_MOUSE.put("vanilla", false);
@@ -1235,6 +1267,8 @@ public class Settings {
     Util.makeDirectory(Dir.REPLAY);
     Dir.WORLDS = Dir.JAR + "/worlds";
     Util.makeDirectory(Dir.WORLDS);
+    Dir.SPEEDRUN = Dir.JAR + "/speedrun";
+    Util.makeDirectory(Dir.SPEEDRUN);
   }
 
   /** Loads properties from config.ini for use with definePresets */
@@ -1539,12 +1573,15 @@ public class Settings {
       props.setProperty("fatigue_notif_value", Integer.toString(FATIGUE_NOTIF_VALUE.get(preset)));
 
       //// streaming
+      props.setProperty("twitch_enabled", Boolean.toString(TWITCH_CHAT_ENABLED.get(preset)));
       props.setProperty("twitch_hide", Boolean.toString(TWITCH_HIDE_CHAT.get(preset)));
       props.setProperty("twitch_channel", TWITCH_CHANNEL.get(preset));
       props.setProperty("twitch_oauth", TWITCH_OAUTH.get(preset));
       props.setProperty("twitch_username", TWITCH_USERNAME.get(preset));
       props.setProperty("show_logindetails", Boolean.toString(SHOW_LOGIN_IP_ADDRESS.get(preset)));
       props.setProperty("save_logininfo", Boolean.toString(SAVE_LOGININFO.get(preset)));
+      props.setProperty("speedrun_active", Boolean.toString(SPEEDRUNNER_MODE_ACTIVE.get(preset)));
+      //props.setProperty("speedrun_username", Settings.SPEEDRUNNER_USERNAME.get(preset));
 
       //// replay
       props.setProperty("record_kb_mouse", Boolean.toString(RECORD_KB_MOUSE.get(preset)));
@@ -1814,6 +1851,13 @@ public class Settings {
       Client.displayMessage("@cya@Object info now hidden", Client.CHAT_NONE);
     }
 
+    save();
+  }
+
+  public static void endSpeedrun() {
+    if (!SPEEDRUNNER_MODE_ACTIVE.get(currentProfile))
+      return;
+    Speedrun.endTheRun();
     save();
   }
 
@@ -2108,6 +2152,7 @@ public class Settings {
     public static String SCREENSHOT;
     public static String REPLAY;
     public static String WORLDS;
+    public static String SPEEDRUN;
   }
 
   /**
@@ -2171,6 +2216,9 @@ public class Settings {
         return true;
       case "toggle_ipdns":
         Settings.toggleShowLoginIpAddress();
+        return true;
+      case "endrun":
+        Settings.endSpeedrun();
         return true;
       case "toggle_item_overlay":
         Settings.toggleShowItemGroundOverlay();
@@ -2247,7 +2295,7 @@ public class Settings {
       case "prev":
         Replay.controlPlayback(commandName);
         return Replay.isPlaying;
-      case "show_xp_bar":
+      case "toggle_xp_bar":
         Settings.toggleXPBar();
         return true;
       case "show_seek_bar":

--- a/src/Client/Speedrun.java
+++ b/src/Client/Speedrun.java
@@ -1,0 +1,329 @@
+/**
+ * rscplus
+ *
+ * <p>This file is part of rscplus.
+ *
+ * <p>rscplus is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * <p>rscplus is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * <p>You should have received a copy of the GNU General Public License along with rscplus. If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ * <p>Authors: see <https://github.com/RSCPlus/rscplus>
+ */
+package Client;
+
+import Game.Client;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Speedrun {
+  static int totalTicks = 0;
+  static ArrayList<Long> startTimes = new ArrayList<>();
+  static ArrayList<Long> endTimes = new ArrayList<>();
+  static boolean active = false;
+  static boolean endTheRUNNN = false;
+  static String finishedSpeedrun = "unknown";
+
+  static final int REASON_NEED_LOAD = -1;
+  static final int REASON_NO_PREVIOUS_FILES = 0;
+  static final int REASON_INVALID_FILE = 1;
+  static final int REASON_LAST_SPEEDRUN_FINISHED = 2;
+  static final int REASON_ALL_OK = 3;
+  static final int REASON_DIFFERENT_ACCOUNT = 4;
+  static final int REASON_UNEXPECTED = 5;
+  static int loadResult = REASON_NEED_LOAD;
+
+  // IDs must not overlap between coordinateGoal & messageGoal.
+  public enum coordinateGoal {
+    TUTORIAL_ISLAND(0, "Tutorial Island", 120, 648), // initial lumbridge spawns
+    CHAMPIONS_GUILD(2, "Champion's Guild", 150, 554); // just inside the champion's guild door
+
+    coordinateGoal(int id, String name, int xCoord, int yCoord) {
+      this.id = id;
+      this.name = name;
+      this.xCoord = xCoord;
+      this.yCoord = yCoord;
+    }
+
+    public int id;
+    public String name;
+    public int xCoord;
+    public int yCoord;
+  }
+
+  public enum messageGoal {
+    BLACK_KNIGHTS_FORTRESS(1, "Black Knight's Fortress", "Well done.You have completed the Black Knights fortress quest"),
+    DRAGON_SLAYER(3, "Dragon Slayer", "Well done you have completed the dragon slayer quest");
+
+    messageGoal(int id, String name, String systemMessage) {
+      this.id = id;
+      this.name = name;
+      this.systemMessage = systemMessage;
+    }
+
+    public int id;
+    public String name;
+    public String systemMessage;
+  }
+  static int goalsDefined = messageGoal.values().length + coordinateGoal.values().length;
+  static int[] completionTicks = new int[goalsDefined];
+  static long[] completionTimes = new long[goalsDefined];
+
+  public static void checkCoordinateCompletions() {
+    if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+      for (coordinateGoal goal : coordinateGoal.values()) {
+        if (completionTimes[goal.id] == 0) {
+          if (goal.xCoord == Client.worldX && goal.yCoord == Client.worldY) {
+            completionTicks[goal.id] = totalTicks;
+            completionTimes[goal.id] = System.currentTimeMillis();
+            printGoalCompletion(goal.name, completionTicks[goal.id], completionTimes[goal.id]);
+          }
+        }
+      }
+    }
+  }
+
+  public static void checkMessageCompletions(String message) {
+    if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+      for (messageGoal goal : messageGoal.values()) {
+        if (completionTimes[goal.id] == 0) {
+          if (goal.systemMessage == message) {
+            completionTicks[goal.id] = totalTicks;
+            completionTimes[goal.id] = System.currentTimeMillis();
+            printGoalCompletion(goal.name, completionTicks[goal.id], completionTimes[goal.id]);
+          }
+        }
+      }
+    }
+  }
+
+  public static void checkAndBeginSpeedrun() {
+    long timeCalled = System.currentTimeMillis();
+    if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+      if (!active) {
+        if (loadResult != REASON_NEED_LOAD) {
+          return;
+        }
+        loadResult = loadSpeedrun();
+
+        switch(loadResult) {
+          case REASON_ALL_OK:
+            Client.displayMessage("Successfully loaded previous run data.", Client.CHAT_QUEST);
+            beginSpeedrun(timeCalled);
+            break;
+          case REASON_LAST_SPEEDRUN_FINISHED:
+            Client.displayMessage(String.format("Last speedrun (%s) finished. Starting new speedrun at %d", finishedSpeedrun, timeCalled), Client.CHAT_QUEST);
+            beginSpeedrun(timeCalled);
+            break;
+          case REASON_NO_PREVIOUS_FILES:
+            beginSpeedrun(timeCalled);
+            break;
+          case REASON_DIFFERENT_ACCOUNT:
+            resetSpeedrun();
+            Client.displayMessage("@red@Not logged into your existing speedrun's account, but speedrunner mode is active.", Client.CHAT_QUEST);
+            Client.displayMessage("@ora@No new speedrun can begin.", Client.CHAT_QUEST);
+            Client.displayMessage("@yel@Rectify this by taking one of the following actions:", Client.CHAT_QUEST);
+            Client.displayMessage("1.) Delete your existing speedrun attempt from " + Settings.Dir.SPEEDRUN, Client.CHAT_QUEST);
+            Client.displayMessage("2.) Log back in to your speedrun account and finish the run.", Client.CHAT_QUEST);
+            Client.displayMessage("3.) Turn off speedrun mode in the config settings.", Client.CHAT_QUEST);
+            Client.displayMessage("4.) Ignore this message & just play but without speedrun timer features.", Client.CHAT_QUEST);
+            Client.displayMessage("@yel@Use <CTRL-O> or right click the tray icon to enter Settings.", Client.CHAT_QUEST);
+            break;
+          case REASON_INVALID_FILE:
+            resetSpeedrun();
+            Client.displayMessage("@red@There is some garbage file in your speedruns folder. Please remove it.", Client.CHAT_QUEST);
+            break;
+          case REASON_UNEXPECTED:
+          default:
+            resetSpeedrun();
+            Client.displayMessage("@red@Exited from loadSpeedrun() in a strange way. Not starting speedrun.", Client.CHAT_QUEST);
+            break;
+        }
+      }
+    }
+  }
+
+  private static void beginSpeedrun(long timeCalled) {
+    active = true;
+    addStartTime(timeCalled);
+  }
+
+  private static void resetSpeedrun() {
+    startTimes.clear();
+    endTimes.clear();
+    completionTicks = new int[goalsDefined];
+    completionTimes = new long[goalsDefined];
+  }
+
+  public static void addStartTime(long startTime) {
+    startTimes.add(startTime);
+    Client.displayMessage(String.format("Starting segment at millisecond %d!!", startTime), Client.CHAT_QUEST);
+  }
+
+  public static void endTheRun() {
+    Settings.SPEEDRUNNER_MODE_ACTIVE.put(Settings.currentProfile, false);
+    endTheRUNNN = true;
+    saveAndQuitSpeedrun();
+  }
+
+  public static void addEndTime(long endTime) {
+    endTimes.add(endTime);
+    Client.displayMessage(String.format("Ending segment at millisecond %d!!", endTime), Client.CHAT_QUEST);
+    printTimeSinceLastSegment(true);
+    printTotalTicks();
+  }
+
+  public static void printGoalCompletion(String name, int ticks, long time) {
+    Client.displayMessage(String.format("Completed %s in %d ticks! (%d millis since last segment)",
+        name, ticks, calcTimeSinceLastSegment(time)), Client.CHAT_QUEST);
+  }
+
+  public static void printTimeSinceLastSegment(boolean referenceEndTimes) {
+    long timeDelta;
+    if (referenceEndTimes) {
+      timeDelta = endTimes.get(endTimes.size() - 1) - startTimes.get(startTimes.size() - 1);
+    } else {
+      timeDelta = calcTimeSinceLastSegment(System.currentTimeMillis());
+    }
+    Client.displayMessage(String.format("Millis since last time segment: %d", timeDelta), Client.CHAT_QUEST);
+  }
+
+  public static long calcTimeSinceLastSegment(long millis) {
+    int startSize = startTimes.size();
+    if (startSize >= 1)
+      return millis - startTimes.get(startSize - 1);
+    else
+      return millis;
+  }
+
+  public static void incrementTicks() {
+    if (active)
+      totalTicks++;
+  }
+
+  public static void printTotalTicks() {
+    Client.displayMessage(String.format("Total ticks spent in speedrun: %d", totalTicks), Client.CHAT_QUEST);
+  }
+
+  public static void saveAndQuitSpeedrun() {
+    loadResult = REASON_NEED_LOAD;
+    if (active) {
+      active = false;
+      addEndTime(System.currentTimeMillis());
+      try {
+        DataOutputStream speedrunData = new DataOutputStream(
+          new BufferedOutputStream(
+              new FileOutputStream(
+                  new File(
+                  Settings.Dir.SPEEDRUN + String.format(
+                      "/%d.%s.bin", startTimes.get(0), Client.username_login.replaceAll("[^a-zA-Z0-9]", ""))
+                  )
+              )
+          )
+        );
+
+        // Header information
+        speedrunData.writeInt(1533546026); // unix timestamp that RSC was taken offline
+        speedrunData.writeBoolean(!endTheRUNNN);
+        if (endTheRUNNN) {
+          endTheRUNNN = false;
+        }
+        speedrunData.writeInt(totalTicks);
+        speedrunData.writeInt(startTimes.size());
+        speedrunData.writeInt(endTimes.size());
+        speedrunData.writeInt(goalsDefined);
+        speedrunData.writeInt(Client.username_login.length());
+        for (int i = 0; i < 32; i++)
+          speedrunData.writeInt(0); // reserved
+
+        // Speedrun data
+        for (long time : startTimes) {
+          speedrunData.writeLong(time);
+        }
+        for (long time : endTimes) {
+          speedrunData.writeLong(time);
+        }
+        for (int i = 0; i < goalsDefined; i++) {
+          speedrunData.writeInt(completionTicks[i]);
+          speedrunData.writeLong(completionTimes[i]);
+        }
+        speedrunData.writeChars(Client.username_login);
+
+        speedrunData.flush();
+        speedrunData.close();
+      } catch (IOException e) {
+        Logger.Error("@|red Couldn't write speedrun save file!|@");
+        Client.displayMessage("@red@Couldn't write speedrun save file!", Client.CHAT_QUEST);
+        Client.displayMessage("Here are your times:", Client.CHAT_QUEST); // TODO
+      }
+    }
+  }
+
+  public static int loadSpeedrun() {
+    File[] fList = new File(Settings.Dir.SPEEDRUN).listFiles();
+    if (fList.length == 0)
+      return REASON_NO_PREVIOUS_FILES;
+    Arrays.sort(fList);
+    File newestData = fList[fList.length - 1];
+    // This file can be "found" again later because the filename is based on startTimes[0], which will remain constant.
+    Logger.Info("Attempting to load speedrun at " + newestData.getAbsolutePath());
+    try {
+      DataInputStream speedrunData =
+          new DataInputStream(new BufferedInputStream(new FileInputStream(newestData)));
+
+      // Check if the file being read is in fact a speedrun save file
+      if (speedrunData.readInt() != 1533546026) {
+        return REASON_INVALID_FILE;
+      }
+      // Check if the speedrun being read already finished (no reason to load)
+      if (!speedrunData.readBoolean()) {
+        finishedSpeedrun = newestData.getName();
+        return REASON_LAST_SPEEDRUN_FINISHED;
+      }
+      totalTicks = speedrunData.readInt();
+      int startTimesSize = speedrunData.readInt();
+      int endTimesSize = speedrunData.readInt();
+      int goalsDefined = speedrunData.readInt();
+      int usernameLength = speedrunData.readInt();
+      for (int i = 0; i < 32; i++)
+        speedrunData.readInt(); // reserved
+
+      startTimes.clear();
+      for (int i = 0; i < startTimesSize; i++) {
+        startTimes.add(speedrunData.readLong());
+      }
+
+      endTimes.clear();
+      for (int i = 0; i < endTimesSize; i++) {
+        endTimes.add(speedrunData.readLong());
+      }
+      for (int i = 0; i < goalsDefined; i++) {
+        completionTicks[i] = speedrunData.readInt();
+        completionTimes[i] = speedrunData.readLong();
+      }
+      char[] usernameArr = new char[usernameLength];
+      for (int i = 0; i < usernameLength; i++)
+        usernameArr[i] = speedrunData.readChar();
+      String loadedUsername = new String(usernameArr);
+
+      if (Client.username_login.equalsIgnoreCase(loadedUsername)) {
+        return REASON_ALL_OK;
+      } else {
+        return REASON_DIFFERENT_ACCOUNT;
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+      Client.displayMessage("@red@Unable to parse speedrun save file!", Client.CHAT_QUEST);
+      Logger.Warn("Unable to parse speedrun save file!");
+    }
+    return REASON_UNEXPECTED;
+  }
+}

--- a/src/Client/Speedrun.java
+++ b/src/Client/Speedrun.java
@@ -231,7 +231,7 @@ public class Speedrun {
         );
 
         // Header information
-        speedrunData.writeInt(1533546026); // unix timestamp that RSC was taken offline
+        speedrunData.writeInt(1533546026); // unix timestamp that RSC was taken offline (2018-08-06 9:00:26 UTC)
         speedrunData.writeBoolean(!endTheRUNNN);
         if (endTheRUNNN) {
           endTheRUNNN = false;

--- a/src/Client/TwitchIRC.java
+++ b/src/Client/TwitchIRC.java
@@ -123,7 +123,7 @@ public class TwitchIRC implements Runnable {
           m_writer.flush();
           // FIXME: Consider thread safety for applet GUI updates outside of its thread?
           Client.displayMessage(
-              "@yel@Connected to @red@[" + Settings.TWITCH_CHANNEL + "]@yel@ Twitch chat",
+              "@yel@Connected to @red@[" + Settings.TWITCH_CHANNEL.get(Settings.currentProfile) + "]@yel@ Twitch chat",
               Client.CHAT_CHAT);
           Client.displayMessage(
               "@lre@Messages starting with @whi@/@lre@ are sent to Twitch.", Client.CHAT_CHAT);
@@ -166,12 +166,12 @@ public class TwitchIRC implements Runnable {
               && message.endsWith(Character.toString((char) 1))) {
             message = message.substring(7, message.length() - 1);
             Client.displayMessage(
-                "@red@[" + Settings.TWITCH_CHANNEL + "] " + username + " @lre@" + message,
+                "@red@[" + Settings.TWITCH_CHANNEL.get(Settings.currentProfile) + "] " + username + " @lre@" + message,
                 Client.CHAT_CHAT);
           } else {
             Client.displayMessage(
                 "@red@["
-                    + Settings.TWITCH_CHANNEL
+                    + Settings.TWITCH_CHANNEL.get(Settings.currentProfile)
                     + "] "
                     + username
                     + "@yel@: "
@@ -192,18 +192,21 @@ public class TwitchIRC implements Runnable {
     } catch (Exception e) {
     }
 
-    // Reconnect on disconnect
+
+    // warn user that twitch irc has lost connection
     if (active) {
       Client.displayMessage(
           "@yel@Disconnected from @red@["
               + Settings.TWITCH_CHANNEL.get(Settings.currentProfile)
-              + "] @yel@, reconnecting in 10 seconds...",
+              + "]@yel@, log back if you'd like to continue chatting.",
           Client.CHAT_CHAT);
+      /* Reconnect on disconnect
       try {
         Thread.sleep(10000);
       } catch (Exception e) {
       }
       connect();
+      */
     }
   }
 
@@ -258,6 +261,8 @@ public class TwitchIRC implements Runnable {
             Client.CHAT_CHAT);
       }
     } catch (Exception e) {
+      if (Settings.LOG_VERBOSITY.get(Settings.currentProfile) >= Logger.Type.DEBUG.id)
+        e.printStackTrace();
     }
   }
 

--- a/src/Client/TwitchIRC.java
+++ b/src/Client/TwitchIRC.java
@@ -100,8 +100,9 @@ public class TwitchIRC implements Runnable {
    * @return If the client is currently configured to use Twitch
    */
   public static boolean isUsing() {
-    return Settings.TWITCH_CHANNEL.get(Settings.currentProfile).length()
-        > 0; // TODO maybe check for an OAUTH/password also?
+    return Settings.TWITCH_CHANNEL.get(Settings.currentProfile).length() > 0 &&
+        Settings.TWITCH_OAUTH.get(Settings.currentProfile).length() > 0 &&
+        Settings.TWITCH_CHAT_ENABLED.get(Settings.currentProfile);
   }
 
   /**
@@ -198,7 +199,7 @@ public class TwitchIRC implements Runnable {
       Client.displayMessage(
           "@yel@Disconnected from @red@["
               + Settings.TWITCH_CHANNEL.get(Settings.currentProfile)
-              + "]@yel@, log back if you'd like to continue chatting.",
+              + "]@yel@, log back in if you'd like to continue chatting.",
           Client.CHAT_CHAT);
       /* Reconnect on disconnect
       try {

--- a/src/Game/Camera.java
+++ b/src/Game/Camera.java
@@ -157,6 +157,9 @@ public class Camera {
   }
 
   public static void strafe(float speed) {
+    if (!Settings.CAMERA_MOVABLE.get(Settings.currentProfile) || Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+      return;
+    }
     float rotation_degrees = ((float) rotation / 255.0f) * 360.0f + 90.0f;
     float xDiff = Util.lengthdir_x(64, rotation_degrees);
     float yDiff = Util.lengthdir_y(64, rotation_degrees);
@@ -164,6 +167,9 @@ public class Camera {
   }
 
   public static void move(float speed) {
+    if (!Settings.CAMERA_MOVABLE.get(Settings.currentProfile) || Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+      return;
+    }
     float rotation_degrees = ((float) rotation / 255.0f) * 360.0f;
     float xDiff = Util.lengthdir_x(64, rotation_degrees);
     float yDiff = Util.lengthdir_y(64, rotation_degrees);

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -678,8 +678,6 @@ public class Client {
     state = STATE_GAME;
     bank_active_page = 0;
     combat_timer = 0;
-
-    if (TwitchIRC.isUsing()) twitch.connect();
   }
 
   public static void login_hook() {
@@ -742,6 +740,7 @@ public class Client {
 
   public static void disconnect_hook() {
     // ::lostcon or closeConnection
+    twitch.disconnect();
     Replay.closeReplayRecording();
   }
 
@@ -861,7 +860,7 @@ public class Client {
       } else {
         twitch.sendMessage(message, true);
       }
-      return "::";
+      return "::null";
     }
 
     line = processClientChatCommand(line);

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -28,6 +28,7 @@ import Client.Logger;
 import Client.NotificationsHandler;
 import Client.NotificationsHandler.NotifType;
 import Client.Settings;
+import Client.Speedrun;
 import Client.TwitchIRC;
 import Replay.game.constants.Game.ItemAction;
 import java.applet.Applet;
@@ -686,7 +687,8 @@ public class Client {
     if (Renderer.replayOption == 2) {
       if (!Replay.initializeReplayPlayback()) Renderer.replayOption = 0;
     } else if (Renderer.replayOption == 1
-        || Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile)) {
+        || Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile)
+        || Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
       Replay.initializeReplayRecording();
     }
 
@@ -742,6 +744,7 @@ public class Client {
     // ::lostcon or closeConnection
     twitch.disconnect();
     Replay.closeReplayRecording();
+    Speedrun.saveAndQuitSpeedrun();
   }
 
   // check if login attempt is not a valid login or reconnect, send to disconnect hook
@@ -992,6 +995,9 @@ public class Client {
             Help.help(0, "help");
           }
           break;
+        case "endrun":
+          Settings.endSpeedrun();
+          break;
         default:
           if (commandArray[0] != null) {
             return "::";
@@ -1201,6 +1207,7 @@ public class Client {
 
   /** Send over the instruction of sleep, if player has sleeping bag with them */
   public static void sleep() {
+    if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) return;
     if (Reflection.itemClick == null) return;
 
     try {
@@ -1340,7 +1347,8 @@ public class Client {
   }
 
   public static int attack_menu_hook(int cmpVar) {
-    if (Settings.ATTACK_ALWAYS_LEFT_CLICK.get(Settings.currentProfile)) {
+    if (Settings.ATTACK_ALWAYS_LEFT_CLICK.get(Settings.currentProfile)
+    && !Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
       return 10;
     } else {
       return cmpVar;
@@ -1654,6 +1662,11 @@ public class Client {
     if (message != null)
       // Prevents non-breaking space in colored usernames appearing as an accented 'a' in console
       message = message.replace("\u00A0", " ");
+
+    if (message != null && username != null) {
+      Speedrun.checkMessageCompletions(message);
+    }
+
     if (type == CHAT_NONE) {
       if (username == null && message != null) {
         if (message.contains("The spell fails! You may try again in 20 seconds"))

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -151,10 +151,12 @@ public class Item {
   }
 
   /**
-   * Patches quest only edible item commands specified by {@link Settings#COMMANDS_PATCH_TYPE}.
+   * Patches quest only edible item commands specified by Settings.COMMANDS_PATCH_TYPE.
    * Swaps around the option to eat/drink
    */
   public static boolean shouldPatch(int index) {
+    if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) return false;
+
     int commandPatchType = Settings.COMMAND_PATCH_TYPE.get(Settings.currentProfile);
     // ids of giant Carp, chocolaty milk, Rock cake, nightshade
     int[] edible_quest_item_ids = {718, 770, 1061, 1086};

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -1012,10 +1012,14 @@ public class Renderer {
       drawShadowText(g2, "-server replay-", bounds.x + 48, bounds.y - 10, color_fatigue, true);
 
       setAlpha(g2, 0.5f);
-      if (replayOption == 1 || Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile)) {
-        g2.setColor(color_low);
+      if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+        g2.setColor(color_hp);
       } else {
-        g2.setColor(color_text);
+        if (replayOption == 1 || Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile)) {
+          g2.setColor(color_low);
+        } else {
+          g2.setColor(color_text);
+        }
       }
       g2.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
@@ -1024,8 +1028,13 @@ public class Renderer {
         g2.drawRect(bounds.x, bounds.y, bounds.width, bounds.height);
       }
 
+
       setAlpha(g2, 1.0f);
-      drawShadowText(g2, "record", bounds.x + (bounds.width / 2), bounds.y + 6, color_text, true);
+      if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
+        drawShadowText(g2, "speedy", bounds.x + (bounds.width / 2), bounds.y + 6, color_text, true);
+      } else {
+        drawShadowText(g2, "record", bounds.x + (bounds.width / 2), bounds.y + 6, color_text, true);
+      }
       // Handle replay record selection click
       if (MouseHandler.x >= bounds.x
           && MouseHandler.x <= bounds.x + bounds.width

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1267,17 +1267,19 @@ public class Replay {
       }
     }
 
-    // SERVER_OPCODE_PLAYER_UPDATE
-    if (opcode == 234) {
-      // Timing should only begin once the player actually exists in the world.
-      // The first time they get a player update packet, we will consider them fully in the world.
-      // This allows time for character creation on tutorial island without counting against speedrun time.
-      Speedrun.checkAndBeginSpeedrun();
-    }
-    // SERVER_OPCODE_PLAYER_COORDS
-    if (opcode == 191) {
-      Speedrun.incrementTicks();
-      Speedrun.checkCoordinateCompletions();
+    if (!isPlaying && !isSeeking) {
+      // SERVER_OPCODE_PLAYER_UPDATE
+      if (opcode == 234) {
+        // Timing should only begin once the player actually exists in the world.
+        // The first time they get a player update packet, we will consider them fully in the world.
+        // This allows time for character creation on tutorial island without counting against speedrun time.
+        Speedrun.checkAndBeginSpeedrun();
+      }
+      // SERVER_OPCODE_PLAYER_COORDS
+      if (opcode == 191) {
+        Speedrun.incrementTicks();
+        Speedrun.checkCoordinateCompletions();
+      }
     }
   }
 

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -23,6 +23,7 @@ import Client.Launcher;
 import Client.Logger;
 import Client.QueueWindow;
 import Client.Settings;
+import Client.Speedrun;
 import Client.Util;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
@@ -1232,7 +1233,8 @@ public class Replay {
   }
 
   public static void checkPoint(int opcode, int len) {
-    if (opcode == 182) { // SERVER_OPCODE_SHOW_WELCOME
+    // SERVER_OPCODE_SHOW_WELCOME
+    if (opcode == 182) {
 
       // getting opcode 182, we can tell that player very recently managed to log in successfully.
       Client.allTheWayLoggedIn();
@@ -1263,6 +1265,19 @@ public class Replay {
         // free memory
         retained_bytes = null;
       }
+    }
+
+    // SERVER_OPCODE_PLAYER_UPDATE
+    if (opcode == 234) {
+      // Timing should only begin once the player actually exists in the world.
+      // The first time they get a player update packet, we will consider them fully in the world.
+      // This allows time for character creation on tutorial island without counting against speedrun time.
+      Speedrun.checkAndBeginSpeedrun();
+    }
+    // SERVER_OPCODE_PLAYER_COORDS
+    if (opcode == 191) {
+      Speedrun.incrementTicks();
+      Speedrun.checkCoordinateCompletions();
     }
   }
 


### PR DESCRIPTION
Giving some love to the Streaming & Privacy tab in this update. :-)

This is definitely the most unused out of all config tabs. Previous to this PR, the TwitchIRC.java file may be the only file in this project that I had never even looked at. Unsurprisingly, with 0 apparent users, the feature broke over time. Somewhat a shame, as it is actually a neat feature. I have brought it back. :-)

-----

Related to streaming, a massive feature implementation comes in this PR, the Speedrun Mode. (#42) I expect that there may be continued additions to this feature in the future, but as it is right now, it is completely usable.

Features include:
1. Detection for the exact time the player enters the world. (Time starts only after first player update packet, allowing time at the character creation screen on tutorial island)
2. Support for detecting 4 different popular categories:
* Tutorial Island
* Black Knight's Fortress
* Entrance to Champion's Guild
* Dragon Slayer
These are implemented by separate "Coordinate Goals" and "Message Goals" checkers.
3. Disabling extensions in RSC+ that give unfair advantage over an unmodified client in a speedrun.
4. Support for saving and loading past segments. (Big Deal!)
5. Settings through the Gui, through Keyboard shortcut, through Command string
6. Interface Cues & In-Client documentation of how the feature works.
7. Automatic calculation of number of ticks & number of milliseconds spent online
8. Ability to end a speedrun at any time with <CTRL-END> or `::endrun` instead of via inflexible programmer definitions.

More features may come later, but for this PR, I feel the feature is complete enough that I can start getting feedback.