### PR TITLE
Overhaul XP Bar system; adds right click menu & new logic

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -560,6 +560,11 @@ public class ConfigWindow {
     generalPanelCheckUpdates.setToolTipText(
         "When enabled, rscplus will check for client updates before launching the game and install them when prompted");
 
+      generalPanelWelcomeEnabled =
+          addCheckbox("Remind you how to open the Settings every time you log in", generalPanel);
+      generalPanelWelcomeEnabled.setToolTipText(
+          "When enabled, rscplus will insert a message telling the current keybinding to open the settings menu and remind you about the tray icon");
+
     generalPanelAccountSecurityCheckbox =
         addCheckbox(
             "Show Account Creation and Security Settings (Requires restart for Account Creation and Recovery)",
@@ -576,15 +581,6 @@ public class ConfigWindow {
         addCheckbox("Show Security tip of the day at login welcome screen", generalPanel);
     generalPanelShowSecurityTipsAtLoginCheckbox.setToolTipText(
         "Displays old RSC Security tip of the day at welcome screen if player has recovery questions permanently set");
-
-    generalPanelWelcomeEnabled =
-        addCheckbox("Remind you how to open the Settings every time you log in", generalPanel);
-    generalPanelWelcomeEnabled.setToolTipText(
-        "When enabled, rscplus will insert a message telling the current keybinding to open the settings menu and remind you about the tray icon");
-
-    generalPanelColoredTextCheckbox = addCheckbox("Colored console text", generalPanel);
-    generalPanelColoredTextCheckbox.setToolTipText(
-        "When running the client from a console, chat messages in the console will reflect the colors they are in game");
 
     generalPanelCustomCursorCheckbox = addCheckbox("Use custom mouse cursor", generalPanel);
     generalPanelCustomCursorCheckbox.setToolTipText(
@@ -688,6 +684,10 @@ public class ConfigWindow {
     generalPanelLogForceLevelCheckbox = addCheckbox("Force log level in log", generalPanel);
     generalPanelLogForceLevelCheckbox.setToolTipText(
         "Forces display of the log level of output in the log");
+
+      generalPanelColoredTextCheckbox = addCheckbox("Colored console text", generalPanel);
+      generalPanelColoredTextCheckbox.setToolTipText(
+          "When running the client from a console, chat messages in the console will reflect the colors they are in game");
 
     generalPanelDebugModeCheckbox = addCheckbox("Enable debug mode", generalPanel);
     generalPanelDebugModeCheckbox.setToolTipText(

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -560,10 +560,10 @@ public class ConfigWindow {
     generalPanelCheckUpdates.setToolTipText(
         "When enabled, rscplus will check for client updates before launching the game and install them when prompted");
 
-      generalPanelWelcomeEnabled =
-          addCheckbox("Remind you how to open the Settings every time you log in", generalPanel);
-      generalPanelWelcomeEnabled.setToolTipText(
-          "When enabled, rscplus will insert a message telling the current keybinding to open the settings menu and remind you about the tray icon");
+    generalPanelWelcomeEnabled =
+        addCheckbox("Remind you how to open the Settings every time you log in", generalPanel);
+    generalPanelWelcomeEnabled.setToolTipText(
+        "When enabled, rscplus will insert a message telling the current keybinding to open the settings menu and remind you about the tray icon");
 
     generalPanelAccountSecurityCheckbox =
         addCheckbox(
@@ -685,9 +685,9 @@ public class ConfigWindow {
     generalPanelLogForceLevelCheckbox.setToolTipText(
         "Forces display of the log level of output in the log");
 
-      generalPanelColoredTextCheckbox = addCheckbox("Colored console text", generalPanel);
-      generalPanelColoredTextCheckbox.setToolTipText(
-          "When running the client from a console, chat messages in the console will reflect the colors they are in game");
+    generalPanelColoredTextCheckbox = addCheckbox("Colored console text", generalPanel);
+    generalPanelColoredTextCheckbox.setToolTipText(
+        "When running the client from a console, chat messages in the console will reflect the colors they are in game");
 
     generalPanelDebugModeCheckbox = addCheckbox("Enable debug mode", generalPanel);
     generalPanelDebugModeCheckbox.setToolTipText(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -3655,7 +3655,8 @@ public class JClassPatcher {
 
             methodNode.instructions.insertBefore(
                 labelNode,
-                new MethodInsnNode(Opcodes.INVOKESTATIC, "Game/Client", "showOtherDialog", "()Z"));
+                new MethodInsnNode(
+                    Opcodes.INVOKESTATIC, "Game/Client", "shouldShowTextInputDialog", "()Z"));
             methodNode.instructions.insertBefore(
                 labelNode, new JumpInsnNode(Opcodes.IFEQ, labelNode));
             methodNode.instructions.insertBefore(labelNode, new VarInsnNode(Opcodes.ALOAD, 0));
@@ -3672,7 +3673,7 @@ public class JClassPatcher {
                 new MethodInsnNode(
                     Opcodes.INVOKESTATIC,
                     "Game/Client",
-                    "drawOtherDialogMouseHook",
+                    "drawTextInputDialogMouseHook",
                     "(III)V",
                     false));
             methodNode.instructions.insertBefore(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2868,10 +2868,7 @@ public class JClassPatcher {
             methodNode.instructions.insertBefore(
                 call,
                 new MethodInsnNode(
-                    Opcodes.INVOKESTATIC,
-                    "Game/AccountManagement",
-                    "ingame_keyhandler_hook",
-                    "(II)I"));
+                    Opcodes.INVOKESTATIC, "Game/Client", "gameKeyPressHook", "(II)I"));
             methodNode.instructions.insertBefore(
                 insnNode, new JumpInsnNode(Opcodes.IFNE, exitNode));
 
@@ -3658,8 +3655,7 @@ public class JClassPatcher {
 
             methodNode.instructions.insertBefore(
                 labelNode,
-                new FieldInsnNode(
-                    Opcodes.GETSTATIC, "Game/AccountManagement", "panelPasswordChangeMode", "I"));
+                new MethodInsnNode(Opcodes.INVOKESTATIC, "Game/Client", "showOtherDialog", "()Z"));
             methodNode.instructions.insertBefore(
                 labelNode, new JumpInsnNode(Opcodes.IFEQ, labelNode));
             methodNode.instructions.insertBefore(labelNode, new VarInsnNode(Opcodes.ALOAD, 0));
@@ -3675,8 +3671,8 @@ public class JClassPatcher {
                 labelNode,
                 new MethodInsnNode(
                     Opcodes.INVOKESTATIC,
-                    "Game/AccountManagement",
-                    "draw_change_pass_hook",
+                    "Game/Client",
+                    "drawOtherDialogMouseHook",
                     "(III)V",
                     false));
             methodNode.instructions.insertBefore(

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Properties;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -316,7 +317,7 @@ public class Launcher extends JFrame implements Runnable {
   public static void main(String[] args) {
     Logger.start();
     Settings.initDir();
-    Settings.initSettings();
+    Properties props = Settings.initSettings();
 
     if (Settings.javaVersion >= 9) {
       Logger.Warn(
@@ -330,6 +331,8 @@ public class Launcher extends JFrame implements Runnable {
     }
 
     setConfigWindow(new ConfigWindow());
+    Settings.loadKeybinds(props);
+    Settings.successfullyInitted = true;
     setQueueWindow(new QueueWindow());
     TrayHandler.initTrayIcon();
     NotificationsHandler.initialize();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -1779,6 +1779,7 @@ public class Settings {
       // XP Goals
       int usernameID = 0;
       for (String username : Client.xpGoals.keySet()) {
+        if (username.equals(XPBar.excludeUsername)) continue;
         for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
           int skillgoal = 0;
           try {

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -1371,36 +1371,39 @@ public class Settings {
       updateInjectedVariables(); // TODO remove this function
 
       // Keybinds
-        if (KeyboardHandler.keybindSetList.size() == 0) {
-            Logger.Debug("No keybinds defined yet, config window not initialized");
-        } else {
-            loadKeybinds(props);
-        }
+      if (KeyboardHandler.keybindSetList.size() == 0) {
+        Logger.Debug("No keybinds defined yet, config window not initialized");
+      } else {
+        loadKeybinds(props);
+      }
 
       // XP
       int numberOfGoalers = getPropInt(props, "numberOfGoalers", 0);
       String[] goalerUsernames = new String[numberOfGoalers];
       for (int usernameID = 0; usernameID < numberOfGoalers; usernameID++) {
-          goalerUsernames[usernameID] = getPropString(props, "username" + usernameID, "");
-          Client.xpGoals.put(goalerUsernames[usernameID], new Integer[Client.NUM_SKILLS]);
-          Client.lvlGoals.put(goalerUsernames[usernameID], new Float[Client.NUM_SKILLS]);
-          for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
-              Client.xpGoals.get(goalerUsernames[usernameID])[skill] =
-                  getPropInt(props, String.format("xpGoal%02d%03d", skill,  usernameID), 0);
-              try {
-                  Client.lvlGoals.get(goalerUsernames[usernameID])[skill] =
-                      Float.parseFloat(getPropString(props, String.format("lvlGoal%02d%03d", skill, usernameID), "0"));
-              } catch (Exception e1) {
-                  Client.lvlGoals.get(goalerUsernames[usernameID])[skill] = new Float(0);
-                  Logger.Warn("Couldn't parse settings key " + String.format("lvlGoal%02d%03d", skill, usernameID));
-              }
+        goalerUsernames[usernameID] = getPropString(props, "username" + usernameID, "");
+        Client.xpGoals.put(goalerUsernames[usernameID], new Integer[Client.NUM_SKILLS]);
+        Client.lvlGoals.put(goalerUsernames[usernameID], new Float[Client.NUM_SKILLS]);
+        for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
+          Client.xpGoals.get(goalerUsernames[usernameID])[skill] =
+              getPropInt(props, String.format("xpGoal%02d%03d", skill, usernameID), 0);
+          try {
+            Client.lvlGoals.get(goalerUsernames[usernameID])[skill] =
+                Float.parseFloat(
+                    getPropString(props, String.format("lvlGoal%02d%03d", skill, usernameID), "0"));
+          } catch (Exception e1) {
+            Client.lvlGoals.get(goalerUsernames[usernameID])[skill] = new Float(0);
+            Logger.Warn(
+                "Couldn't parse settings key "
+                    + String.format("lvlGoal%02d%03d", skill, usernameID));
           }
+        }
       }
-        XPBar.pinnedBar = getPropBoolean(props,"pinXPBar", false);
-        XPBar.pinnedSkill = getPropInt(props, "pinnedSkill", -1);
+      XPBar.pinnedBar = getPropBoolean(props, "pinXPBar", false);
+      XPBar.pinnedSkill = getPropInt(props, "pinnedSkill", -1);
 
-        Logger.Info("Loaded settings");
-        return props;
+      Logger.Info("Loaded settings");
+      return props;
 
     } catch (Exception e) {
       e.printStackTrace();
@@ -1409,37 +1412,37 @@ public class Settings {
   }
 
   public static Properties loadProps() {
-      Properties props = new Properties();
+    Properties props = new Properties();
 
-      try {
-          File configFile = new File(Dir.JAR + "/config.ini");
-          if (!configFile.isDirectory()) {
-              if (!configFile.exists()) {
-                  definePresets(props);
-                  save("custom");
-              }
-          }
-
-          FileInputStream in = new FileInputStream(Dir.JAR + "/config.ini");
-          props.load(in);
-          in.close();
-      } catch (Exception e) {
-          Logger.Warn("Error loading config.ini");
-          e.printStackTrace();
+    try {
+      File configFile = new File(Dir.JAR + "/config.ini");
+      if (!configFile.isDirectory()) {
+        if (!configFile.exists()) {
+          definePresets(props);
+          save("custom");
+        }
       }
-      return props;
+
+      FileInputStream in = new FileInputStream(Dir.JAR + "/config.ini");
+      props.load(in);
+      in.close();
+    } catch (Exception e) {
+      Logger.Warn("Error loading config.ini");
+      e.printStackTrace();
+    }
+    return props;
   }
 
   public static void loadKeybinds(Properties props) {
-      if (props == null) {
-          props = loadProps();
-      }
-      for (KeybindSet kbs : KeyboardHandler.keybindSetList) {
-          String keybindCombo =
-              getPropString(props, "key_" + kbs.commandName, "" + kbs.modifier + "*" + kbs.key);
-          kbs.modifier = getKeyModifierFromString(keybindCombo);
-          kbs.key = Integer.parseInt(keybindCombo.substring(2));
-      }
+    if (props == null) {
+      props = loadProps();
+    }
+    for (KeybindSet kbs : KeyboardHandler.keybindSetList) {
+      String keybindCombo =
+          getPropString(props, "key_" + kbs.commandName, "" + kbs.modifier + "*" + kbs.key);
+      kbs.modifier = getKeyModifierFromString(keybindCombo);
+      kbs.key = Integer.parseInt(keybindCombo.substring(2));
+    }
   }
 
   public static void initWorlds() {
@@ -1608,7 +1611,8 @@ public class Settings {
 
   public static void save(String preset) {
     if (!successfullyInitted) {
-        Logger.Warn("Prevented erroneous save, please report this along with the RSC+ log file, set to debug logging mode");
+      Logger.Warn(
+          "Prevented erroneous save, please report this along with the RSC+ log file, set to debug logging mode");
       return;
     }
     try {
@@ -1775,24 +1779,26 @@ public class Settings {
       // XP Goals
       int usernameID = 0;
       for (String username : Client.xpGoals.keySet()) {
-          for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
-              int skillgoal = 0;
-              try {
-                  skillgoal = Client.xpGoals.get(username)[skill];
-              } catch (Exception noGoal) {}
-
-              float lvlgoal = (float)0;
-              try {
-                  lvlgoal = Client.lvlGoals.get(username)[skill];
-              } catch (Exception noGoal) {}
-
-              props.setProperty(String.format("xpGoal%02d%03d", skill,  usernameID),
-                  Integer.toString(skillgoal));
-              props.setProperty(String.format("lvlGoal%02d%03d", skill,  usernameID),
-                  Float.toString(lvlgoal));
+        for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
+          int skillgoal = 0;
+          try {
+            skillgoal = Client.xpGoals.get(username)[skill];
+          } catch (Exception noGoal) {
           }
-          props.setProperty(String.format("username%d", usernameID), username);
-          usernameID++;
+
+          float lvlgoal = (float) 0;
+          try {
+            lvlgoal = Client.lvlGoals.get(username)[skill];
+          } catch (Exception noGoal) {
+          }
+
+          props.setProperty(
+              String.format("xpGoal%02d%03d", skill, usernameID), Integer.toString(skillgoal));
+          props.setProperty(
+              String.format("lvlGoal%02d%03d", skill, usernameID), Float.toString(lvlgoal));
+        }
+        props.setProperty(String.format("username%d", usernameID), username);
+        usernameID++;
       }
       props.setProperty("numberOfGoalers", String.format("%d", usernameID));
 
@@ -1803,7 +1809,7 @@ public class Settings {
       props.store(out, "---rscplus config---");
       out.close();
     } catch (Exception e) {
-        e.printStackTrace();
+      e.printStackTrace();
       Logger.Error("Unable to save settings");
     }
   }

--- a/src/Game/AccountManagement.java
+++ b/src/Game/AccountManagement.java
@@ -1046,7 +1046,7 @@ public class AccountManagement {
         panelPasswordChangeMode = 3;
         return;
       }
-    } else if (panelPasswordChangeMode < 8){
+    } else if (panelPasswordChangeMode < 8) {
       if (panelPasswordChangeMode == 3) {
         Renderer.drawStringCenter("Passwords do not match!", Renderer.width / 2, yPos, 4, 0xFFFFFF);
         yPos += 25;
@@ -1078,55 +1078,64 @@ public class AccountManagement {
         return;
       }
     } else {
-        // TODO: this is bad practice, but I'm putting XPBar code in this file
-        // so that I don't have to reimplement this input box.
-        // If we're going to do this, this entire method should be put in some other file, possibly its own class
-        if (panelPasswordChangeMode == 8) {
-            Renderer.drawStringCenter(
-                "Please enter your XP or level goal", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-            yPos += 25;
+      // TODO: this is bad practice, but I'm putting XPBar code in this file
+      // so that I don't have to reimplement this input box.
+      // If we're going to do this, this entire method should be put in some other file, possibly
+      // its own class
+      if (panelPasswordChangeMode == 8) {
+        Renderer.drawStringCenter(
+            "Please enter your XP or level goal", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+        yPos += 25;
 
-            Renderer.drawStringCenter(Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-            if (Client.modal_text.length() > 0) {
-                int goal = -1;
-                try {
-                    goal = Integer.parseInt(Client.modal_text);
-                } catch (NumberFormatException e ) {
-                    panelPasswordChangeMode = 9;
-                    return;
-                }
+        Renderer.drawStringCenter(
+            Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+        if (Client.modal_text.length() > 0) {
+          int goal = -1;
+          try {
+            goal = Integer.parseInt(Client.modal_text);
+          } catch (NumberFormatException e) {
+            panelPasswordChangeMode = 9;
+            return;
+          }
 
-                Client.xpbar.setXpGoal(goal);
-                Client.modal_enteredText = "";
-                Client.modal_text = "";
-                panelPasswordChangeMode = 0;
-                return;
-            }
-
-        } else if (panelPasswordChangeMode == 9) {
-            Renderer.drawStringCenter(
-                "Numbers only, please", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-            yPos += 25;
-
-            Renderer.drawStringCenter(Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-            if (Client.modal_text.length() > 0) {
-                int goal = -1;
-                try {
-                    goal = Integer.parseInt(Client.modal_text);
-                } catch (NumberFormatException e ) {
-                    panelPasswordChangeMode = 9;
-                    return;
-                }
-
-                Client.xpbar.setXpGoal(goal);
-                Client.modal_enteredText = "";
-                Client.modal_text = "";
-                panelPasswordChangeMode = 0;
-                return;
-            }
-
+          Client.xpbar.setXpGoal(goal);
+          Client.modal_enteredText = "";
+          Client.modal_text = "";
+          panelPasswordChangeMode = 0;
+          return;
         }
+
+      } else if (panelPasswordChangeMode == 9) {
+        Renderer.drawStringCenter("Numbers only, please", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+        yPos += 25;
+
+        Renderer.drawStringCenter(
+            Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+        if (Client.modal_text.length() > 0) {
+          int goal = -1;
+          try {
+            goal = Integer.parseInt(Client.modal_text);
+          } catch (NumberFormatException e) {
+            panelPasswordChangeMode = 9;
+            return;
+          }
+
+          Client.xpbar.setXpGoal(goal);
+          Client.modal_enteredText = "";
+          Client.modal_text = "";
+          panelPasswordChangeMode = 0;
+          return;
+        }
+      }
     }
+  }
+
+  public static boolean shouldShowPassChange() {
+    return panelPasswordChangeMode > 0;
+  }
+
+  public static boolean shouldConsumeKey() {
+    return Client.showRecoveryQuestions || Client.showContactDetails || panelPasswordChangeMode > 0;
   }
 
   public static void processForgotPassword() {
@@ -1366,8 +1375,6 @@ public class AccountManagement {
    * For any other non-zero password change state, non-zero response given
    */
   public static int ingame_keyhandler_hook(int loggedIn, int key) {
-    if (loggedIn != 1) return 0;
-
     if (Client.showRecoveryQuestions) {
       if (customQuestionEntry != -1) return 1;
       Panel.handleKey(Client.panelRecoveryQuestions, key);

--- a/src/Game/AccountManagement.java
+++ b/src/Game/AccountManagement.java
@@ -1037,7 +1037,7 @@ public class AccountManagement {
         panelPasswordChangeMode = 3;
         return;
       }
-    } else {
+    } else if (panelPasswordChangeMode < 8){
       if (panelPasswordChangeMode == 3) {
         Renderer.drawStringCenter("Passwords do not match!", Renderer.width / 2, yPos, 4, 0xFFFFFF);
         yPos += 25;
@@ -1068,6 +1068,55 @@ public class AccountManagement {
             "the same as your username", Renderer.width / 2, yPos, 4, 0xFFFFFF);
         return;
       }
+    } else {
+        // TODO: this is bad practice, but I'm putting XPBar code in this file
+        // so that I don't have to reimplement this input box.
+        // If we're going to do this, this entire method should be put in some other file, possibly its own class
+        if (panelPasswordChangeMode == 8) {
+            Renderer.drawStringCenter(
+                "Please enter your XP or level goal", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+            yPos += 25;
+
+            Renderer.drawStringCenter(Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+            if (Client.modal_text.length() > 0) {
+                int goal = -1;
+                try {
+                    goal = Integer.parseInt(Client.modal_text);
+                } catch (NumberFormatException e ) {
+                    panelPasswordChangeMode = 9;
+                    return;
+                }
+
+                Client.xpbar.setXpGoal(goal);
+                Client.modal_enteredText = "";
+                Client.modal_text = "";
+                panelPasswordChangeMode = 0;
+                return;
+            }
+
+        } else if (panelPasswordChangeMode == 9) {
+            Renderer.drawStringCenter(
+                "Numbers only, please", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+            yPos += 25;
+
+            Renderer.drawStringCenter(Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+            if (Client.modal_text.length() > 0) {
+                int goal = -1;
+                try {
+                    goal = Integer.parseInt(Client.modal_text);
+                } catch (NumberFormatException e ) {
+                    panelPasswordChangeMode = 9;
+                    return;
+                }
+
+                Client.xpbar.setXpGoal(goal);
+                Client.modal_enteredText = "";
+                Client.modal_text = "";
+                panelPasswordChangeMode = 0;
+                return;
+            }
+
+        }
     }
   }
 

--- a/src/Game/AccountManagement.java
+++ b/src/Game/AccountManagement.java
@@ -960,7 +960,7 @@ public class AccountManagement {
     return currYPos - yPos;
   }
 
-  public static void draw_change_pass_hook(int mouseX, int mouseY, int mouseButtonClick) {
+  public static void drawChangePassInput(int mouseX, int mouseY, int mouseButtonClick) {
     if (mouseButtonClick != 0) {
       mouseButtonClick = 0;
       if (mouseX < Renderer.width / 2 - 150
@@ -1076,56 +1076,6 @@ public class AccountManagement {
         Renderer.drawStringCenter(
             "the same as your username", Renderer.width / 2, yPos, 4, 0xFFFFFF);
         return;
-      }
-    } else {
-      // TODO: this is bad practice, but I'm putting XPBar code in this file
-      // so that I don't have to reimplement this input box.
-      // If we're going to do this, this entire method should be put in some other file, possibly
-      // its own class
-      if (panelPasswordChangeMode == 8) {
-        Renderer.drawStringCenter(
-            "Please enter your XP or level goal", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-        yPos += 25;
-
-        Renderer.drawStringCenter(
-            Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-        if (Client.modal_text.length() > 0) {
-          int goal = -1;
-          try {
-            goal = Integer.parseInt(Client.modal_text);
-          } catch (NumberFormatException e) {
-            panelPasswordChangeMode = 9;
-            return;
-          }
-
-          Client.xpbar.setXpGoal(goal);
-          Client.modal_enteredText = "";
-          Client.modal_text = "";
-          panelPasswordChangeMode = 0;
-          return;
-        }
-
-      } else if (panelPasswordChangeMode == 9) {
-        Renderer.drawStringCenter("Numbers only, please", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-        yPos += 25;
-
-        Renderer.drawStringCenter(
-            Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
-        if (Client.modal_text.length() > 0) {
-          int goal = -1;
-          try {
-            goal = Integer.parseInt(Client.modal_text);
-          } catch (NumberFormatException e) {
-            panelPasswordChangeMode = 9;
-            return;
-          }
-
-          Client.xpbar.setXpGoal(goal);
-          Client.modal_enteredText = "";
-          Client.modal_text = "";
-          panelPasswordChangeMode = 0;
-          return;
-        }
       }
     }
   }
@@ -1374,7 +1324,7 @@ public class AccountManagement {
    * response is given to break out of trying to consume key on other panels
    * For any other non-zero password change state, non-zero response given
    */
-  public static int ingame_keyhandler_hook(int loggedIn, int key) {
+  public static int keyHandler(int key) {
     if (Client.showRecoveryQuestions) {
       if (customQuestionEntry != -1) return 1;
       Panel.handleKey(Client.panelRecoveryQuestions, key);

--- a/src/Game/AccountManagement.java
+++ b/src/Game/AccountManagement.java
@@ -81,8 +81,8 @@ public class AccountManagement {
         StreamUtil.initializeStream(Client.server_address, port);
         StreamUtil.setStreamMaxRetries(Client.maxRetries);
 
-        Client.session_id =
-            0; // TODO: should read int to get session ID here, triggered by TCP handshake
+        // TODO: should read an int to get session ID here, triggered by TCP handshake
+        Client.session_id = 0;
 
         StreamUtil.newPacket(2);
         Object buffer = StreamUtil.getStreamBuffer();
@@ -170,8 +170,8 @@ public class AccountManagement {
       StreamUtil.initializeStream(Client.server_address, port);
       StreamUtil.setStreamMaxRetries(Client.maxRetries);
 
-      Client.session_id =
-          0; // TODO: should read int to get session ID here, triggered by TCP handshake
+      // TODO: should read an int to get session ID here, triggered by TCP handshake
+      Client.session_id = 0;
 
       StreamUtil.newPacket(4);
       Object buffer = StreamUtil.getStreamBuffer();
@@ -251,8 +251,8 @@ public class AccountManagement {
       StreamUtil.initializeStream(Client.server_address, port);
       StreamUtil.setStreamMaxRetries(Client.maxRetries);
 
-      Client.session_id =
-          0; // TODO: should read int to get session ID here, triggered by TCP handshake
+      // TODO: should read an int to get session ID here, triggered by TCP handshake
+      Client.session_id = 0;
 
       String oldPass =
           Client.formatText(

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -1081,11 +1081,13 @@ public class Client {
 
   /**
    * Extensible method hooking to draw other dialog boxes and consuming mouse method. Branching
-   * should match conditions inside showOtherDialog()
+   * should match conditions inside showTextInputDialog()
    */
-  public static void drawOtherDialogMouseHook(int mouseX, int mouseY, int mouseButtonClick) {
+  public static void drawTextInputDialogMouseHook(int mouseX, int mouseY, int mouseButtonClick) {
     if (AccountManagement.shouldShowPassChange()) {
-      AccountManagement.draw_change_pass_hook(mouseX, mouseY, mouseButtonClick);
+      AccountManagement.drawChangePassInput(mouseX, mouseY, mouseButtonClick);
+    } else if (XPBar.shouldShowGoalInput()) {
+      XPBar.drawGoalXPInput(mouseX, mouseY, mouseButtonClick);
     }
   }
 
@@ -1097,7 +1099,9 @@ public class Client {
     if (loggedIn != 1) {
       return 0;
     } else if (AccountManagement.shouldConsumeKey()) {
-      return AccountManagement.ingame_keyhandler_hook(loggedIn, key);
+      return AccountManagement.keyHandler(key);
+    } else if (XPBar.shouldConsumeKey()) {
+      return XPBar.keyHandler();
     }
     return 0;
   }
@@ -1148,9 +1152,9 @@ public class Client {
     return shouldShow;
   }
 
-  /** Return true if there is pending render to show other box dialog */
-  public static boolean showOtherDialog() {
-    return AccountManagement.shouldShowPassChange();
+  /** Return true if there is pending render to show the text-input-box dialog */
+  public static boolean shouldShowTextInputDialog() {
+    return AccountManagement.shouldShowPassChange() || XPBar.shouldShowGoalInput();
   }
 
   public static void drawInputPopupHook(int popupType) {

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2431,15 +2431,17 @@ public class Client {
   }
 
   public static float getLevelFromXP(float xp) {
-      float lvl = 1;
-      // 136.53725 is the maximum level you can reach in RSC before XP rolls over negative
-      for (; lvl <= 137 && getXPforLevel((int)lvl) <= xp; lvl++) {}
 
-      float xpToLevel = (float)Math.floor(getXPforLevel((int)lvl) - xp);
+      // 136.53725 is the maximum level you can reach in RSC before XP rolls over negative
+      int lvl = 1;
+      while (lvl <= 137 && getXPforLevel(lvl) <= xp) {
+          lvl++;
+      }
+      float xpToLevel = (float)Math.floor(getXPforLevel(lvl) - xp);
       if (xpToLevel > 0) {
           lvl--;
-          float xpIntoLevel = (float)Math.floor(xp - getXPforLevel((int)lvl));
-          float xpBetweenLevels = (getXPforLevel((int)lvl + 1) - getXPforLevel((int)lvl));
+          float xpIntoLevel = (float)Math.floor(xp - getXPforLevel(lvl));
+          float xpBetweenLevels = (getXPforLevel(lvl + 1) - getXPforLevel(lvl));
           return lvl + (xpIntoLevel / xpBetweenLevels);
       } else {
           return lvl;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -305,7 +305,6 @@ public class Client {
    * - [3] and the total number of XP drops recorded within the sample period, plus 1.
    */
   private static final int TOTAL_XP_GAIN = 0;
-
   private static final int TIME_OF_LAST_XP_DROP = 1;
   private static final int TIME_OF_FIRST_XP_DROP = 2;
   private static final int TOTAL_XP_DROPS = 3;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -731,41 +731,41 @@ public class Client {
       }
 
     // Process XP drops
-    for (int i = 0; i < NUM_SKILLS; i++) {
+    for (int skill = 0; skill < NUM_SKILLS; skill++) {
 
-       xpGain[i] = getXP(i) - xpLast.get(xpUsername)[i];
-        xpLast.get(xpUsername)[i] += xpGain[i];
+       xpGain[skill] = getXP(skill) - xpLast.get(xpUsername)[skill];
+        xpLast.get(xpUsername)[skill] += xpGain[skill];
 
-      if (xpGain[i] > 0.0f) {
+      if (xpGain[skill] > 0.0f) {
         if (Settings.SHOW_XPDROPS.get(Settings.currentProfile))
-          xpdrop_handler.add("+" + xpGain[i] + " (" + skill_name[i] + ")", Renderer.color_text);
+          xpdrop_handler.add("+" + xpGain[skill] + " (" + skill_name[skill] + ")", Renderer.color_text);
 
         // XP/hr calculations
 
       // calc last xp gain
-      lastXpGain.get(xpUsername)[i][LAST_XP_GAIN] = new Double(xpGain[i]);
+      lastXpGain.get(xpUsername)[skill][LAST_XP_GAIN] = new Double(xpGain[skill]);
 
       // calc total xp gain
-      lastXpGain.get(xpUsername)[i][TOTAL_XP_GAIN] = xpGain[i] + lastXpGain.get(xpUsername)[i][TOTAL_XP_GAIN];
+      lastXpGain.get(xpUsername)[skill][TOTAL_XP_GAIN] = xpGain[skill] + lastXpGain.get(xpUsername)[skill][TOTAL_XP_GAIN];
 
       // calc xp/hr
-      xpPerHour.get(xpUsername)[i] =
-          3600 * (lastXpGain.get(xpUsername)[i][TOTAL_XP_GAIN]) / ((System.currentTimeMillis() - lastXpGain.get(xpUsername)[i][TIME_OF_FIRST_XP_DROP]) / 1000);
+      xpPerHour.get(xpUsername)[skill] =
+          3600 * (lastXpGain.get(xpUsername)[skill][TOTAL_XP_GAIN]) / ((System.currentTimeMillis() - lastXpGain.get(xpUsername)[skill][TIME_OF_FIRST_XP_DROP]) / 1000);
 
       // increment xp drops
-      lastXpGain.get(xpUsername)[i][TOTAL_XP_DROPS]++;
+      lastXpGain.get(xpUsername)[skill][TOTAL_XP_DROPS]++;
 
       // display xp/hr or not
-      if (lastXpGain.get(xpUsername)[i][TOTAL_XP_DROPS] > 1) {
-          showXpPerHour.get(xpUsername)[i] = true;
+      if (lastXpGain.get(xpUsername)[skill][TOTAL_XP_DROPS] > 1) {
+          showXpPerHour.get(xpUsername)[skill] = true;
       }
 
       // update time since last xp drop
-      lastXpGain.get(xpUsername)[i][TIME_OF_LAST_XP_DROP] = (double)System.currentTimeMillis();
+      lastXpGain.get(xpUsername)[skill][TIME_OF_LAST_XP_DROP] = (double)System.currentTimeMillis();
 
-        if (i == SKILL_HP && xpbar.current_skill != -1) continue;
+        if (skill == SKILL_HP && xpbar.current_skill != -1) continue;
 
-        xpbar.setSkill(i);
+        xpbar.setSkill(skill);
       }
     }
 
@@ -804,14 +804,14 @@ public class Client {
           showXpPerHour.put(xpUsername, new Boolean[NUM_SKILLS]);
           xpPerHour.put(xpUsername, new Double[NUM_SKILLS]);
           xpLast.put(xpUsername, new Float[NUM_SKILLS]);
-          for (int i = 0; i < NUM_SKILLS; i++) {
-              lastXpGain.get(xpUsername)[i][TOTAL_XP_GAIN] = new Double(0);
-              lastXpGain.get(xpUsername)[i][TIME_OF_FIRST_XP_DROP] =
-                  lastXpGain.get(xpUsername)[i][TIME_OF_LAST_XP_DROP] = new Double(System.currentTimeMillis());
-              lastXpGain.get(xpUsername)[i][TOTAL_XP_DROPS] = new Double(0);
+          for (int skill = 0; skill < NUM_SKILLS; skill++) {
+              lastXpGain.get(xpUsername)[skill][TOTAL_XP_GAIN] = new Double(0);
+              lastXpGain.get(xpUsername)[skill][TIME_OF_FIRST_XP_DROP] =
+                  lastXpGain.get(xpUsername)[skill][TIME_OF_LAST_XP_DROP] = new Double(System.currentTimeMillis());
+              lastXpGain.get(xpUsername)[skill][TOTAL_XP_DROPS] = new Double(0);
 
-              showXpPerHour.get(xpUsername)[i] = false;
-              xpPerHour.get(xpUsername)[i] = new Double(0);
+              showXpPerHour.get(xpUsername)[skill] = false;
+              xpPerHour.get(xpUsername)[skill] = new Double(0);
           }
       }
       if (xpGoals.get(xpUsername) == null) {
@@ -1450,24 +1450,24 @@ public class Client {
         return subline;
 
       } else if (command.startsWith("next_")) {
-        for (int i = 0; i < NUM_SKILLS; i++) {
-          if (command.equals("next_" + skill_name[i].toLowerCase())) {
+        for (int skill = 0; skill < NUM_SKILLS; skill++) {
+          if (command.equals("next_" + skill_name[skill].toLowerCase())) {
             final float neededXp =
-                base_level[i] == 99 ? 0 : getXPforLevel(base_level[i] + 1) - getXP(i);
+                base_level[skill] == 99 ? 0 : getXPforLevel(base_level[skill] + 1) - getXP(skill);
             return "I need "
                 + neededXp
                 + " more xp for "
-                + (base_level[i] == 99 ? 99 : base_level[i] + 1)
+                + (base_level[skill] == 99 ? 99 : base_level[skill] + 1)
                 + " "
-                + skill_name[i]
+                + skill_name[skill]
                 + ".";
           }
         }
       }
 
-      for (int i = 0; i < NUM_SKILLS; i++) {
-        if (command.equalsIgnoreCase(skill_name[i]))
-          return "My " + skill_name[i] + " level is " + base_level[i] + " (" + getXP(i) + " xp).";
+      for (int skill = 0; skill < NUM_SKILLS; skill++) {
+        if (command.equalsIgnoreCase(skill_name[skill]))
+          return "My " + skill_name[skill] + " level is " + base_level[skill] + " (" + getXP(skill) + " xp).";
       }
     }
 
@@ -2483,7 +2483,7 @@ public class Client {
    */
   public static int getTotalLevel() {
     int total = 0;
-    for (int i = 0; i < NUM_SKILLS; i++) total += Client.base_level[i];
+    for (int skill = 0; skill < NUM_SKILLS; skill++) total += Client.base_level[skill];
     return total;
   }
 
@@ -2494,7 +2494,7 @@ public class Client {
    */
   public static float getTotalXP() {
     float xp = 0;
-    for (int i = 0; i < NUM_SKILLS; i++) xp += getXP(i);
+    for (int skill = 0; skill < NUM_SKILLS; skill++) xp += getXP(skill);
     return xp;
   }
 

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -293,22 +293,19 @@ public class Client {
   /** An array to store the XP per hour for a given skill */
   private static HashMap<String, Double[]> xpPerHour = new HashMap<String, Double[]>();
 
-  /**
-   * A multi-dimensional array that stores the last time XP was gained for a given skill.
-   *
-   * <p>The first dimension stores the skill index corresponding to the constants defined in the
-   * client class ( {@link #SKILL_ATTACK}, etc.)<br>
-   * The second dimension stores:<br>
-   * - [0] the total XP gained in a given skill within the sample period,<br>
-   * - [1] the time of the last XP drop in a given skill,<br>
-   * - [2] the time of the first XP drop in a given skill within the sample period,<br>
-   * - [3] and the total number of XP drops recorded within the sample period, plus 1.
-   */
+  // the total XP gained in a given skill within the sample period
   private static final int TOTAL_XP_GAIN = 0;
+  // the time of the last XP drop in a given skill
   private static final int TIME_OF_LAST_XP_DROP = 1;
+  // the time of the first XP drop in a given skill within the sample period
   private static final int TIME_OF_FIRST_XP_DROP = 2;
+  // the total number of XP drops recorded within the sample period, plus 1
   private static final int TOTAL_XP_DROPS = 3;
+  // the amount of XP gained since last processed
   private static final int LAST_XP_GAIN = 4;
+
+  // first dimension of this array is skill ID.
+  // second dimension is the constants in block above.
   private static HashMap<String, Double[][]> lastXpGain = new HashMap<String, Double[][]>();
 
   // holds players XP since last processing xp drops

--- a/src/Game/MouseHandler.java
+++ b/src/Game/MouseHandler.java
@@ -42,6 +42,7 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
 
   public static boolean inBounds(Rectangle bounds) {
     if (XPBar.hoveringOverMenu || XPBar.hoveringOverBar()) {
+        XPBar.hoveringOverMenu = false;
       return true;
     }
     if (bounds == null) return false;

--- a/src/Game/MouseHandler.java
+++ b/src/Game/MouseHandler.java
@@ -42,11 +42,13 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
 
   public static boolean inBounds(Rectangle bounds) {
     if (XPBar.hoveringOverMenu || XPBar.hoveringOverBar()) {
-        XPBar.hoveringOverMenu = false;
+      XPBar.hoveringOverMenu = false;
       return true;
     }
     if (bounds == null) return false;
-    if (Replay.isPlaying && Settings.SHOW_PLAYER_CONTROLS.get(Settings.currentProfile) && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile)) {
+    if (Replay.isPlaying
+        && Settings.SHOW_PLAYER_CONTROLS.get(Settings.currentProfile)
+        && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile)) {
       return MouseHandler.x >= bounds.x
           && MouseHandler.x <= bounds.x + bounds.width
           && MouseHandler.y >= bounds.y

--- a/src/Game/MouseHandler.java
+++ b/src/Game/MouseHandler.java
@@ -41,14 +41,17 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
   private float m_rotateX = 0.0f;
 
   public static boolean inBounds(Rectangle bounds) {
+    if (XPBar.hoveringOverMenu || XPBar.hoveringOverBar()) {
+      return true;
+    }
     if (bounds == null) return false;
-    if (Replay.isPlaying && Settings.SHOW_PLAYER_CONTROLS.get(Settings.currentProfile)) {
+    if (Replay.isPlaying && Settings.SHOW_PLAYER_CONTROLS.get(Settings.currentProfile) && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile)) {
       return MouseHandler.x >= bounds.x
           && MouseHandler.x <= bounds.x + bounds.width
           && MouseHandler.y >= bounds.y
           && MouseHandler.y <= bounds.y + bounds.height;
     }
-    return false; // add handling for buttons that aren't playback related here
+    return false;
   }
 
   public boolean inConsumableButton() {

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -403,11 +403,9 @@ public class Renderer {
                 drawHighlighImage(g2, itemText, x, y);
               }
 
-              // TODO: it would be nice if for items like Coins or Runes, we showed how many of the
-              // item were on the ground instead of how many times you have to click to pick them
-              // all up.
-              // Currently will just show "Coins (2)" if there are two stacks of coins on the
-              // ground.
+              // Note that it is not possible to show how many of a
+              //   stackable item are in a stack on the ground.
+              // That information is not transmitted in RSC, just that the item ID is there.
               drawShadowText(g2, itemText, x, y, itemColor, true);
             }
             last_item = item; // Done with item this loop, can save it as last_item

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -413,7 +413,6 @@ public class Renderer {
             last_item = item; // Done with item this loop, can save it as last_item
           }
         }
-
       }
 
       if (!Client.isSleeping()) {
@@ -887,8 +886,8 @@ public class Renderer {
         int offset = 0;
         if (Client.is_in_wild) offset += 70;
         if (Replay.isPlaying) {
-            if ((!screenshot && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
-                || Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) y -= 12;
+          if ((!screenshot && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
+              || Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) y -= 12;
         }
         if ((!Replay.isPlaying || screenshot)
             && Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) offset += 70;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -886,8 +886,10 @@ public class Renderer {
         y = Renderer.height - 19;
         int offset = 0;
         if (Client.is_in_wild) offset += 70;
-        if ((!screenshot && Replay.isPlaying && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
-            || Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) y -= 12;
+        if (Replay.isPlaying) {
+            if ((!screenshot && Settings.SHOW_SEEK_BAR.get(Settings.currentProfile))
+                || Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) y -= 12;
+        }
         if ((!Replay.isPlaying || screenshot)
             && Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) offset += 70;
         drawShadowText(

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -414,7 +414,6 @@ public class Renderer {
           }
         }
 
-        Client.processFatigueXPDrops();
       }
 
       if (!Client.isSleeping()) {
@@ -664,6 +663,7 @@ public class Renderer {
       // Clear npc list for the next frame
       Client.npc_list.clear();
 
+      Client.processFatigueXPDrops();
       Client.xpdrop_handler.draw(g2);
       Client.xpbar.draw(g2);
 

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1277,8 +1277,8 @@ public class Replay {
         Speedrun.checkAndBeginSpeedrun();
 
         if (!Client.knowWhoIAm) {
-            Client.knowWhoIAm = true;
-            Client.resetFatigueXPDrops(true);
+          Client.knowWhoIAm = true;
+          Client.resetFatigueXPDrops(true);
         }
       }
       // SERVER_OPCODE_PLAYER_COORDS

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1287,13 +1287,13 @@ public class Replay {
         Speedrun.checkCoordinateCompletions();
       }
     } else {
-        // in a replay, just make sure knowWhoIAm is set
-        if (opcode == 234) {
-            if (!Client.knowWhoIAm) {
-                Client.knowWhoIAm = true;
-                Client.resetFatigueXPDrops(true);
-            }
+      // in a replay, just make sure knowWhoIAm is set
+      if (opcode == 234) {
+        if (!Client.knowWhoIAm) {
+          Client.knowWhoIAm = true;
+          Client.resetFatigueXPDrops(true);
         }
+      }
     }
   }
 

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1275,6 +1275,11 @@ public class Replay {
         // This allows time for character creation on tutorial island without counting against
         // speedrun time.
         Speedrun.checkAndBeginSpeedrun();
+
+        if (!Client.knowWhoIAm) {
+            Client.knowWhoIAm = true;
+            Client.resetFatigueXPDrops(true);
+        }
       }
       // SERVER_OPCODE_PLAYER_COORDS
       if (opcode == 191) {

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -271,7 +271,7 @@ public class Replay {
       while (!replayServer.isReady) Thread.sleep(1);
     } catch (Exception e) {
     }
-    Client.login(false, "Replay", "");
+    Client.login(false, XPBar.excludeUsername, "");
     updateFrameTimeSlice();
     return true;
   }
@@ -1286,6 +1286,14 @@ public class Replay {
         Speedrun.incrementTicks();
         Speedrun.checkCoordinateCompletions();
       }
+    } else {
+        // in a replay, just make sure knowWhoIAm is set
+        if (opcode == 234) {
+            if (!Client.knowWhoIAm) {
+                Client.knowWhoIAm = true;
+                Client.resetFatigueXPDrops(true);
+            }
+        }
     }
   }
 

--- a/src/Game/ReplayServer.java
+++ b/src/Game/ReplayServer.java
@@ -166,7 +166,7 @@ public class ReplayServer implements Runnable {
       // Let's connect our client
       Logger.Debug("ReplayServer: Syncing playback to client...");
       isReady = true;
-      client = sock.accept();  // waiting for Replay.initializeReplayPlayback()
+      client = sock.accept(); // waiting for Replay.initializeReplayPlayback()
       client.setOption(TCP_NODELAY, new Boolean(true));
 
       Logger.Debug("ReplayServer: Starting playback; port=" + usePort);

--- a/src/Game/ReplayServer.java
+++ b/src/Game/ReplayServer.java
@@ -166,7 +166,7 @@ public class ReplayServer implements Runnable {
       // Let's connect our client
       Logger.Debug("ReplayServer: Syncing playback to client...");
       isReady = true;
-      client = sock.accept();
+      client = sock.accept();  // waiting for Replay.initializeReplayPlayback()
       client.setOption(TCP_NODELAY, new Boolean(true));
 
       Logger.Debug("ReplayServer: Starting playback; port=" + usePort);

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -32,7 +32,7 @@ public class XPBar {
   public static int drawGoalInputState = 0;
 
   // when replay is initialized, client.username_login will be set to this
-  public final static String excludeUsername = "excludemefromxpbartracking";
+  public static final String excludeUsername = "excludemefromxpbartracking";
 
   public static Dimension bounds = new Dimension(110, 16);
   public static Dimension menuBounds = new Dimension(110, 56);

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -31,6 +31,9 @@ public class XPBar {
   public static int pinnedSkill = -1;
   public static int drawGoalInputState = 0;
 
+  // when replay is initialized, client.username_login will be set to this
+  public final static String excludeUsername = "excludemefromxpbartracking";
+
   public static Dimension bounds = new Dimension(110, 16);
   public static Dimension menuBounds = new Dimension(110, 56);
   public static int xp_bar_x;

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -19,17 +19,16 @@
 package Game;
 
 import Client.Settings;
-
 import java.awt.*;
 import java.text.NumberFormat;
 
 /** Handles rendering the XP bar and hover information */
 public class XPBar {
-    public static boolean showingMenu = false;
-    public static boolean hoveringOverMenu = false;
-    private static float alpha;
-    public static boolean pinnedBar = false;
-    public static int pinnedSkill = -1;
+  public static boolean showingMenu = false;
+  public static boolean hoveringOverMenu = false;
+  private static float alpha;
+  public static boolean pinnedBar = false;
+  public static int pinnedSkill = -1;
 
   public static Dimension bounds = new Dimension(110, 16);
   public static Dimension menuBounds = new Dimension(110, 56);
@@ -69,26 +68,24 @@ public class XPBar {
       current_skill = -1;
       return;
     }
-      if (pinnedSkill > 0) {
-          current_skill = pinnedSkill;
-      }
+    if (pinnedSkill > 0) {
+      current_skill = pinnedSkill;
+    }
 
     if (current_skill == -1) return;
 
     long delta = m_timer - Renderer.time;
     alpha = 1.0f;
-      if (!pinnedBar) {
-          // Don't fade in if XP bar is already displayed
-          if (delta >= TIMER_LENGTH - 250 && last_timer_finished) {
-              // Fade in over 1/4th second
-              alpha = (float) (TIMER_LENGTH - delta) / 250.0f;
-          } else if (delta < TIMER_FADEOUT) {
-              // Less than TIMER_FADEOUT milliseconds left to display the XP bar
-              alpha = (float) delta / TIMER_FADEOUT;
-          }
+    if (!pinnedBar) {
+      // Don't fade in if XP bar is already displayed
+      if (delta >= TIMER_LENGTH - 250 && last_timer_finished) {
+        // Fade in over 1/4th second
+        alpha = (float) (TIMER_LENGTH - delta) / 250.0f;
+      } else if (delta < TIMER_FADEOUT) {
+        // Less than TIMER_FADEOUT milliseconds left to display the XP bar
+        alpha = (float) delta / TIMER_FADEOUT;
       }
-
-
+    }
 
     int skill_current_xp = (int) Client.getXPforLevel(Client.getBaseLevel(current_skill));
     int skill_next_xp = (int) Client.getXPforLevel(Client.getBaseLevel(current_skill) + 1);
@@ -141,291 +138,265 @@ public class XPBar {
         Renderer.color_text,
         true);
 
-
     // Draw additional menus
-      hoveringOverMenu = (MouseHandler.x >= x &&
-          MouseHandler.x <= x + menuBounds.width &&
-          MouseHandler.y > y &&
-          MouseHandler.y < y + bounds.height + menuBounds.height &&
-          showingMenu);
+    hoveringOverMenu =
+        (MouseHandler.x >= x
+            && MouseHandler.x <= x + menuBounds.width
+            && MouseHandler.y > y
+            && MouseHandler.y < y + bounds.height + menuBounds.height
+            && showingMenu);
 
     if (hoveringOverBar()) {
-        if (MouseHandler.mouseClicked) {
-            showingMenu = true;
-        } else {
-            if (!showingMenu) {
-                drawInfoBox(g, x, y, current_skill, post99xp);
-            }
+      if (MouseHandler.mouseClicked) {
+        showingMenu = true;
+      } else {
+        if (!showingMenu) {
+          drawInfoBox(g, x, y, current_skill, post99xp);
         }
+      }
       // Don't allow XP bar to disappear while user is still interacting with it.
       if (delta < TIMER_FADEOUT + 100) {
         m_timer += TIMER_FADEOUT + 1500;
         last_timer_finished = false;
       }
     } else {
-        if (!hoveringOverMenu) {
-            showingMenu = false;
-        } else {
-            if (delta < TIMER_FADEOUT + 100) {
-                m_timer += TIMER_FADEOUT + 1500;
-                last_timer_finished = false;
-            }
+      if (!hoveringOverMenu) {
+        showingMenu = false;
+      } else {
+        if (delta < TIMER_FADEOUT + 100) {
+          m_timer += TIMER_FADEOUT + 1500;
+          last_timer_finished = false;
         }
+      }
     }
 
-    if (showingMenu)
-        drawMenu(g, x, y);
+    if (showingMenu) drawMenu(g, x, y);
 
     Renderer.setAlpha(g, 1.0f);
   }
 
-
   static boolean hoveringOverBar() {
-      return MouseHandler.x >= xp_bar_x
-          && MouseHandler.x <= xp_bar_x + bounds.width
-          && MouseHandler.y > xp_bar_y
-          && MouseHandler.y < xp_bar_y + bounds.height
-          && alpha > 0.01;
+    return MouseHandler.x >= xp_bar_x
+        && MouseHandler.x <= xp_bar_x + bounds.width
+        && MouseHandler.y > xp_bar_y
+        && MouseHandler.y < xp_bar_y + bounds.height
+        && alpha > 0.01;
   }
 
   private void drawMenu(Graphics2D g, int x, int y) {
-      x = xp_bar_x;
-      y = xp_bar_y + bounds.height;
+    x = xp_bar_x;
+    y = xp_bar_y + bounds.height;
 
-      g.setColor(Renderer.color_gray);
-      Renderer.setAlpha(g, 0.7f);
-      g.fillRect(x, y, menuBounds.width, menuBounds.height);
+    g.setColor(Renderer.color_gray);
+    Renderer.setAlpha(g, 0.7f);
+    g.fillRect(x, y, menuBounds.width, menuBounds.height);
 
-      Renderer.setAlpha(g, 1.0f);
+    Renderer.setAlpha(g, 1.0f);
 
-      x += 8;
-      Color textColour;
+    x += 8;
+    Color textColour;
 
-      int offset = 2;
-      int textHeight = 12 + offset;
+    int offset = 2;
+    int textHeight = 12 + offset;
 
-      // Option 0
-      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
-          textColour = Renderer.color_yellow;
-          if (MouseHandler.mouseClicked) {
-              resetXPGainStart();
-          }
-      } else {
-          textColour = Renderer.color_text;
+    // Option 0
+    if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+      textColour = Renderer.color_yellow;
+      if (MouseHandler.mouseClicked) {
+        resetXPGainStart();
       }
-      y += 12;
-      Renderer.drawShadowText(
-          g, "Reset XP period",
-          x,
-          y,
-          textColour,
-          false);
+    } else {
+      textColour = Renderer.color_text;
+    }
+    y += 12;
+    Renderer.drawShadowText(g, "Reset XP period", x, y, textColour, false);
 
-      // Option 1
-      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
-          textColour = Renderer.color_yellow;
-          if (MouseHandler.mouseClicked) {
-              setXPGoal();
-          }
-      } else {
-          textColour = Renderer.color_text;
+    // Option 1
+    if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+      textColour = Renderer.color_yellow;
+      if (MouseHandler.mouseClicked) {
+        setXPGoal();
       }
-      y += 12;
-      Renderer.drawShadowText(
-          g, hasGoalForSkill(current_skill) ? "Clear Goal": "Set Goal",
-          x,
-          y,
-          textColour,
-          false);
+    } else {
+      textColour = Renderer.color_text;
+    }
+    y += 12;
+    Renderer.drawShadowText(
+        g, hasGoalForSkill(current_skill) ? "Clear Goal" : "Set Goal", x, y, textColour, false);
 
-      // Option 2
-      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
-          textColour = Renderer.color_yellow;
-          if (MouseHandler.mouseClicked) {
-              pinSkill();
-          }
-      } else {
-          textColour = Renderer.color_text;
+    // Option 2
+    if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+      textColour = Renderer.color_yellow;
+      if (MouseHandler.mouseClicked) {
+        pinSkill();
       }
-      y += 12;
-      Renderer.drawShadowText(
-          g, pinnedSkill > 0 ? "Use recent skill" : "Keep this skill",
-          x,
-          y,
-          textColour,
-          false);
+    } else {
+      textColour = Renderer.color_text;
+    }
+    y += 12;
+    Renderer.drawShadowText(
+        g, pinnedSkill > 0 ? "Use recent skill" : "Keep this skill", x, y, textColour, false);
 
-      // Option 3
-      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
-          textColour = Renderer.color_yellow;
-          if (MouseHandler.mouseClicked) {
-              togglePinnedBar();
-          }
-      } else {
-          textColour = Renderer.color_text;
+    // Option 3
+    if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+      textColour = Renderer.color_yellow;
+      if (MouseHandler.mouseClicked) {
+        togglePinnedBar();
       }
-      y += 12;
-      Renderer.drawShadowText(
-          g, pinnedBar ? "Unpin bar" :"Pin bar",
-          x,
-          y,
-          textColour,
-          false);
+    } else {
+      textColour = Renderer.color_text;
+    }
+    y += 12;
+    Renderer.drawShadowText(g, pinnedBar ? "Unpin bar" : "Pin bar", x, y, textColour, false);
   }
 
   private void pinSkill() {
-      if (pinnedSkill > 0) {
-        pinnedSkill = -1;
-      } else {
-        pinnedSkill = current_skill;
-      }
-
+    if (pinnedSkill > 0) {
+      pinnedSkill = -1;
+    } else {
+      pinnedSkill = current_skill;
+    }
   }
 
   private void resetXPGainStart() {
-      Client.resetFatigueXPDrops(true);
+    Client.resetFatigueXPDrops(true);
   }
 
   private void setXPGoal() {
-      if (hasGoalForSkill(current_skill)) {
-          Client.xpGoals.get(Client.xpUsername)[current_skill] = 0;
-      } else {
-          Client.modal_enteredText = "";
-          Client.modal_text = "";
-          AccountManagement.panelPasswordChangeMode = 8;
-      }
+    if (hasGoalForSkill(current_skill)) {
+      Client.xpGoals.get(Client.xpUsername)[current_skill] = 0;
+    } else {
+      Client.modal_enteredText = "";
+      Client.modal_text = "";
+      AccountManagement.panelPasswordChangeMode = 8;
+    }
   }
 
   public void setXpGoal(int xpGoal) {
-      if (xpGoal <= 120) {
-          // assume it's a level, translate to XP
-          xpGoal = (int)Client.getXPforLevel(xpGoal);
-      }
-      Client.xpGoals.get(Client.xpUsername)[current_skill] = xpGoal;
-      Client.lvlGoals.get(Client.xpUsername)[current_skill] = Client.getLevelFromXP(xpGoal);
-      Settings.save();
+    if (xpGoal <= 120) {
+      // assume it's a level, translate to XP
+      xpGoal = (int) Client.getXPforLevel(xpGoal);
+    }
+    Client.xpGoals.get(Client.xpUsername)[current_skill] = xpGoal;
+    Client.lvlGoals.get(Client.xpUsername)[current_skill] = Client.getLevelFromXP(xpGoal);
+    Settings.save();
   }
 
   private void togglePinnedBar() {
-      pinnedBar = !pinnedBar;
+    pinnedBar = !pinnedBar;
   }
 
   private static void drawInfoBox(Graphics2D g, int x, int y, int current_skill, boolean post99xp) {
-      // Draw info box
-      x = MouseHandler.x;
-      y = MouseHandler.y + 24;
-      g.setColor(Renderer.color_gray);
-      Renderer.setAlpha(g, 0.7f);
+    // Draw info box
+    x = MouseHandler.x;
+    y = MouseHandler.y + 24;
+    g.setColor(Renderer.color_gray);
+    Renderer.setAlpha(g, 0.7f);
 
-      int height = 50;
+    int height = 50;
 
+    if (Client.getShowXpPerHour()[current_skill]) {
+      height += 12;
+    }
+    if (!post99xp) {
+      height += 20;
       if (Client.getShowXpPerHour()[current_skill]) {
-          height += 12;
+        height += 12;
       }
-      if (!post99xp) {
-         height += 20;
-          if (Client.getShowXpPerHour()[current_skill]) {
-              height += 12;
-          }
-      }
-      if (hasGoalForSkill(current_skill)) {
-          height += 32;
-          if (Client.getShowXpPerHour()[current_skill]) {
-             height += 12;
-          }
-      }
-
-      // Draw new rect
-      g.fillRect(x - 100, y, 200, height);
-
-      Renderer.setAlpha(g, 1.0f);
-      y += 12;
-
-      Renderer.drawShadowText(
-          g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
-      y += 12;
+    }
+    if (hasGoalForSkill(current_skill)) {
+      height += 32;
       if (Client.getShowXpPerHour()[current_skill]) {
-          Renderer.drawShadowText(
-              g,
-              "XP/Hr: " + formatXP(Client.getXpPerHour()[current_skill]),
-              x,
-              y,
-              Renderer.color_text,
-              true);
-          y += 12;
+        height += 12;
       }
+    }
 
-      y += 8;
+    // Draw new rect
+    g.fillRect(x - 100, y, 200, height);
 
+    Renderer.setAlpha(g, 1.0f);
+    y += 12;
 
-      if (!post99xp) {
-          Renderer.drawShadowText(
-              g,
-              "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
-              x,
-              y,
-              Renderer.color_text,
-              true);
-          y += 12;
-          if (Client.getShowXpPerHour()[current_skill]) {
-              Renderer.drawShadowText(
-                  g,
-                  "Actions until Level: "
-                      + formatXP(Client.getXPUntilLevel(current_skill) / Client.getLastXpGain(current_skill)),
-                  x,
-                  y,
-                  Renderer.color_text,
-                  true);
-              y += 12;
-          }
-          y += 8;
-      }
-
-      if (hasGoalForSkill(current_skill)) {
-          Renderer.drawShadowText(
-              g,
-              "XP until Goal: " + formatXP(Client.getXPUntilGoal(current_skill)),
-              x,
-              y,
-              Renderer.color_text,
-              true);
-          y += 12;
-          if (Client.getShowXpPerHour()[current_skill]) {
-              Renderer.drawShadowText(
-                  g,
-                  "Actions until Goal: "
-                      + formatXP(Client.getXPUntilGoal(current_skill) / Client.getLastXpGain(current_skill)),
-                  x,
-                  y,
-                  Renderer.color_text,
-                  true);
-              y += 12;
-          }
-          Renderer.drawShadowText(
-              g,
-              "Current Goal Level: " + Client.lvlGoals.get(Client.xpUsername)[current_skill],
-              x,
-              y,
-              Renderer.color_text,
-              true);
-          y += 12;
-          y += 8;
-      }
+    Renderer.drawShadowText(
+        g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
+    y += 12;
+    if (Client.getShowXpPerHour()[current_skill]) {
       Renderer.drawShadowText(
           g,
-          "Right-click for more options",
+          "XP/Hr: " + formatXP(Client.getXpPerHour()[current_skill]),
           x,
           y,
           Renderer.color_text,
           true);
+      y += 12;
+    }
+
+    y += 8;
+
+    if (!post99xp) {
+      Renderer.drawShadowText(
+          g,
+          "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
+          x,
+          y,
+          Renderer.color_text,
+          true);
+      y += 12;
+      if (Client.getShowXpPerHour()[current_skill]) {
+        Renderer.drawShadowText(
+            g,
+            "Actions until Level: "
+                + formatXP(
+                    Client.getXPUntilLevel(current_skill) / Client.getLastXpGain(current_skill)),
+            x,
+            y,
+            Renderer.color_text,
+            true);
+        y += 12;
+      }
+      y += 8;
+    }
+
+    if (hasGoalForSkill(current_skill)) {
+      Renderer.drawShadowText(
+          g,
+          "XP until Goal: " + formatXP(Client.getXPUntilGoal(current_skill)),
+          x,
+          y,
+          Renderer.color_text,
+          true);
+      y += 12;
+      if (Client.getShowXpPerHour()[current_skill]) {
+        Renderer.drawShadowText(
+            g,
+            "Actions until Goal: "
+                + formatXP(
+                    Client.getXPUntilGoal(current_skill) / Client.getLastXpGain(current_skill)),
+            x,
+            y,
+            Renderer.color_text,
+            true);
+        y += 12;
+      }
+      Renderer.drawShadowText(
+          g,
+          "Current Goal Level: " + Client.lvlGoals.get(Client.xpUsername)[current_skill],
+          x,
+          y,
+          Renderer.color_text,
+          true);
+      y += 12;
+      y += 8;
+    }
+    Renderer.drawShadowText(g, "Right-click for more options", x, y, Renderer.color_text, true);
   }
 
   public static boolean hasGoalForSkill(int skill) {
-      try {
-          return Client.xpGoals.get(Client.xpUsername)[skill] > 0;
-      } catch (Exception e) {
-          return false;
-      }
+    try {
+      return Client.xpGoals.get(Client.xpUsername)[skill] > 0;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   /**

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -29,6 +29,7 @@ public class XPBar {
   private static float alpha;
   public static boolean pinnedBar = false;
   public static int pinnedSkill = -1;
+  public static int drawGoalInputState = 0;
 
   public static Dimension bounds = new Dimension(110, 16);
   public static Dimension menuBounds = new Dimension(110, 56);
@@ -268,7 +269,7 @@ public class XPBar {
     } else {
       Client.modal_enteredText = "";
       Client.modal_text = "";
-      AccountManagement.panelPasswordChangeMode = 8;
+      drawGoalInputState = 8;
     }
   }
 
@@ -408,5 +409,85 @@ public class XPBar {
    */
   public static String formatXP(double number) {
     return NumberFormat.getIntegerInstance().format(Math.ceil(number));
+  }
+
+  /*
+   *   Goal Input code below this line
+   * ===================================
+   */
+
+  public static boolean shouldShowGoalInput() {
+    return drawGoalInputState != 0;
+  }
+
+  public static boolean shouldConsumeKey() {
+    return shouldShowGoalInput();
+  }
+
+  public static int keyHandler() {
+    return (shouldConsumeKey() ? 1 : 0);
+  }
+
+  public static void drawGoalXPInput(int mouseX, int mouseY, int mouseButtonClick) {
+    if (mouseButtonClick != 0) {
+      mouseButtonClick = 0;
+      if (mouseX < Renderer.width / 2 - 150
+          || mouseY < Renderer.height / 2 - 32
+          || mouseX > Renderer.width / 2 + 150
+          || mouseY > Renderer.height / 2 + 28) {
+        drawGoalInputState = 0;
+        return;
+      }
+    }
+    int yPos = Renderer.height / 2 - 32;
+    Renderer.drawBox(Renderer.width / 2 - 150, yPos, 300, 60, 0);
+    Renderer.drawBoxBorder(Renderer.width / 2 - 150, yPos, 300, 60, 0xFFFFFF);
+    yPos += 22;
+
+    if (drawGoalInputState == 8) {
+      Renderer.drawStringCenter(
+          "Please enter your XP or level goal", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+      yPos += 25;
+
+      Renderer.drawStringCenter(
+          Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+      if (Client.modal_text.length() > 0) {
+        int goal = -1;
+        try {
+          goal = Integer.parseInt(Client.modal_text);
+        } catch (NumberFormatException e) {
+          drawGoalInputState = 9;
+          return;
+        }
+
+        Client.xpbar.setXpGoal(goal);
+        Client.modal_enteredText = "";
+        Client.modal_text = "";
+        drawGoalInputState = 0;
+        return;
+      }
+
+    } else if (drawGoalInputState == 9) {
+      Renderer.drawStringCenter("Numbers only, please", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+      yPos += 25;
+
+      Renderer.drawStringCenter(
+          Client.modal_enteredText + "*", Renderer.width / 2, yPos, 4, 0xFFFFFF);
+      if (Client.modal_text.length() > 0) {
+        int goal = -1;
+        try {
+          goal = Integer.parseInt(Client.modal_text);
+        } catch (NumberFormatException e) {
+          drawGoalInputState = 9;
+          return;
+        }
+
+        Client.xpbar.setXpGoal(goal);
+        Client.modal_enteredText = "";
+        Client.modal_text = "";
+        drawGoalInputState = 0;
+        return;
+      }
+    }
   }
 }

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -266,6 +266,7 @@ public class XPBar {
   private void setXPGoal() {
     if (hasGoalForSkill(current_skill)) {
       Client.xpGoals.get(Client.xpUsername)[current_skill] = 0;
+      Settings.save();
     } else {
       Client.modal_enteredText = "";
       Client.modal_text = "";

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -19,14 +19,20 @@
 package Game;
 
 import Client.Settings;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
+
+import java.awt.*;
 import java.text.NumberFormat;
 
 /** Handles rendering the XP bar and hover information */
 public class XPBar {
+    public static boolean showingMenu = false;
+    public static boolean hoveringOverMenu = false;
+    private static float alpha;
+    public static boolean pinnedBar = false;
+    public static int pinnedSkill = -1;
 
   public static Dimension bounds = new Dimension(110, 16);
+  public static Dimension menuBounds = new Dimension(110, 56);
   public static int xp_bar_x;
   // Don't need to set this more than once; we are always positioning the xp_bar to be vertically
   // center aligned with
@@ -59,22 +65,30 @@ public class XPBar {
    * @param g the Graphics2D object
    */
   void draw(Graphics2D g) {
-    if (Renderer.time > m_timer) {
+    if (Renderer.time > m_timer && !pinnedBar) {
       current_skill = -1;
       return;
     }
+      if (pinnedSkill > 0) {
+          current_skill = pinnedSkill;
+      }
 
     if (current_skill == -1) return;
 
     long delta = m_timer - Renderer.time;
+    alpha = 1.0f;
+      if (!pinnedBar) {
+          // Don't fade in if XP bar is already displayed
+          if (delta >= TIMER_LENGTH - 250 && last_timer_finished) {
+              // Fade in over 1/4th second
+              alpha = (float) (TIMER_LENGTH - delta) / 250.0f;
+          } else if (delta < TIMER_FADEOUT) {
+              // Less than TIMER_FADEOUT milliseconds left to display the XP bar
+              alpha = (float) delta / TIMER_FADEOUT;
+          }
+      }
 
-    float alpha = 1.0f;
-    if (delta >= TIMER_LENGTH - 250
-        && last_timer_finished) // Don't fade in if XP bar is already displayed
-    alpha = (float) (TIMER_LENGTH - delta) / 250.0f; // Fade in over 1/4th second
-    else if (delta
-        < TIMER_FADEOUT) // Less than TIMER_FADEOUT milliseconds left to display the XP bar
-    alpha = (float) delta / TIMER_FADEOUT;
+
 
     int skill_current_xp = (int) Client.getXPforLevel(Client.getBaseLevel(current_skill));
     int skill_next_xp = (int) Client.getXPforLevel(Client.getBaseLevel(current_skill) + 1);
@@ -127,79 +141,291 @@ public class XPBar {
         Renderer.color_text,
         true);
 
-    // Draw info box
-    if (MouseHandler.x >= x
-        && MouseHandler.x <= x + bounds.width
-        && MouseHandler.y > y
-        && MouseHandler.y < y + bounds.height) {
-      x = MouseHandler.x;
-      y = MouseHandler.y + 16;
-      g.setColor(Renderer.color_gray);
-      Renderer.setAlpha(g, 0.5f);
-      if (Client.getShowXpPerHour()[current_skill]) {
-        if (!post99xp) {
-          g.fillRect(x - 100, y, 200, 60);
+
+    // Draw additional menus
+      hoveringOverMenu = (MouseHandler.x >= x &&
+          MouseHandler.x <= x + menuBounds.width &&
+          MouseHandler.y > y &&
+          MouseHandler.y < y + bounds.height + menuBounds.height &&
+          showingMenu);
+
+    if (hoveringOverBar()) {
+        if (MouseHandler.mouseClicked) {
+            showingMenu = true;
         } else {
-          g.fillRect(x - 100, y, 200, 48);
+            if (!showingMenu) {
+                drawInfoBox(g, x, y, current_skill, post99xp);
+            }
         }
-      } else {
-        g.fillRect(x - 100, y, 200, 36);
-      }
-      Renderer.setAlpha(g, 1.0f);
-
-      y += 8;
-
-      if (!post99xp) {
-        Renderer.drawShadowText(
-            g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
-        y += 12;
-        Renderer.drawShadowText(
-            g,
-            "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
-            x,
-            y,
-            Renderer.color_text,
-            true);
-        y += 12;
-      } else {
-        y += 8;
-        Renderer.drawShadowText(
-            g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
-        y += 12;
-      }
-      if (Client.getShowXpPerHour()[current_skill]) {
-        Renderer.drawShadowText(
-            g,
-            "XP/Hr: " + formatXP(Client.getXpPerHour()[current_skill]),
-            x,
-            y,
-            Renderer.color_text,
-            true);
-        y += 12;
-        if (!post99xp) {
-          Renderer.drawShadowText(
-              g,
-              "Actions until Level: "
-                  + formatXP(
-                      Client.getXPUntilLevel(current_skill)
-                          / (Client.getLastXpGain()[current_skill][0]
-                              / (Client.getLastXpGain()[current_skill][3] + 1))),
-              x,
-              y,
-              Renderer.color_text,
-              true);
-          y += 12;
-        }
-      }
-
       // Don't allow XP bar to disappear while user is still interacting with it.
       if (delta < TIMER_FADEOUT + 100) {
         m_timer += TIMER_FADEOUT + 1500;
         last_timer_finished = false;
       }
+    } else {
+        if (!hoveringOverMenu) {
+            showingMenu = false;
+        } else {
+            if (delta < TIMER_FADEOUT + 100) {
+                m_timer += TIMER_FADEOUT + 1500;
+                last_timer_finished = false;
+            }
+        }
     }
 
+    if (showingMenu)
+        drawMenu(g, x, y);
+
     Renderer.setAlpha(g, 1.0f);
+  }
+
+
+  static boolean hoveringOverBar() {
+      return MouseHandler.x >= xp_bar_x
+          && MouseHandler.x <= xp_bar_x + bounds.width
+          && MouseHandler.y > xp_bar_y
+          && MouseHandler.y < xp_bar_y + bounds.height
+          && alpha > 0.01;
+  }
+
+  private void drawMenu(Graphics2D g, int x, int y) {
+      x = xp_bar_x;
+      y = xp_bar_y + bounds.height;
+
+      g.setColor(Renderer.color_gray);
+      Renderer.setAlpha(g, 0.7f);
+      g.fillRect(x, y, menuBounds.width, menuBounds.height);
+
+      Renderer.setAlpha(g, 1.0f);
+
+      x += 8;
+      Color textColour;
+
+      int offset = 2;
+      int textHeight = 12 + offset;
+
+      // Option 0
+      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+          textColour = Renderer.color_yellow;
+          if (MouseHandler.mouseClicked) {
+              resetXPGainStart();
+          }
+      } else {
+          textColour = Renderer.color_text;
+      }
+      y += 12;
+      Renderer.drawShadowText(
+          g, "Reset XP period",
+          x,
+          y,
+          textColour,
+          false);
+
+      // Option 1
+      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+          textColour = Renderer.color_yellow;
+          if (MouseHandler.mouseClicked) {
+              setXPGoal();
+          }
+      } else {
+          textColour = Renderer.color_text;
+      }
+      y += 12;
+      Renderer.drawShadowText(
+          g, hasGoalForSkill(current_skill) ? "Clear Goal": "Set Goal",
+          x,
+          y,
+          textColour,
+          false);
+
+      // Option 2
+      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+          textColour = Renderer.color_yellow;
+          if (MouseHandler.mouseClicked) {
+              pinSkill();
+          }
+      } else {
+          textColour = Renderer.color_text;
+      }
+      y += 12;
+      Renderer.drawShadowText(
+          g, pinnedSkill > 0 ? "Use recent skill" : "Keep this skill",
+          x,
+          y,
+          textColour,
+          false);
+
+      // Option 3
+      if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+          textColour = Renderer.color_yellow;
+          if (MouseHandler.mouseClicked) {
+              togglePinnedBar();
+          }
+      } else {
+          textColour = Renderer.color_text;
+      }
+      y += 12;
+      Renderer.drawShadowText(
+          g, pinnedBar ? "Unpin bar" :"Pin bar",
+          x,
+          y,
+          textColour,
+          false);
+  }
+
+  private void pinSkill() {
+      if (pinnedSkill > 0) {
+        pinnedSkill = -1;
+      } else {
+        pinnedSkill = current_skill;
+      }
+
+  }
+
+  private void resetXPGainStart() {
+      Client.resetFatigueXPDrops(true);
+  }
+
+  private void setXPGoal() {
+      if (hasGoalForSkill(current_skill)) {
+          Client.xpGoals.get(Client.xpUsername)[current_skill] = 0;
+      } else {
+          Client.modal_enteredText = "";
+          Client.modal_text = "";
+          AccountManagement.panelPasswordChangeMode = 8;
+      }
+  }
+
+  public void setXpGoal(int xpGoal) {
+      if (xpGoal <= 120) {
+          // assume it's a level, translate to XP
+          xpGoal = (int)Client.getXPforLevel(xpGoal);
+      }
+      Client.xpGoals.get(Client.xpUsername)[current_skill] = xpGoal;
+      Client.lvlGoals.get(Client.xpUsername)[current_skill] = Client.getLevelFromXP(xpGoal);
+      Settings.save();
+  }
+
+  private void togglePinnedBar() {
+      pinnedBar = !pinnedBar;
+  }
+
+  private static void drawInfoBox(Graphics2D g, int x, int y, int current_skill, boolean post99xp) {
+      // Draw info box
+      x = MouseHandler.x;
+      y = MouseHandler.y + 24;
+      g.setColor(Renderer.color_gray);
+      Renderer.setAlpha(g, 0.7f);
+
+      int height = 50;
+
+      if (Client.getShowXpPerHour()[current_skill]) {
+          height += 12;
+      }
+      if (!post99xp) {
+         height += 20;
+          if (Client.getShowXpPerHour()[current_skill]) {
+              height += 12;
+          }
+      }
+      if (hasGoalForSkill(current_skill)) {
+          height += 32;
+          if (Client.getShowXpPerHour()[current_skill]) {
+             height += 12;
+          }
+      }
+
+      // Draw new rect
+      g.fillRect(x - 100, y, 200, height);
+
+      Renderer.setAlpha(g, 1.0f);
+      y += 12;
+
+      Renderer.drawShadowText(
+          g, "XP: " + formatXP(Client.getXP(current_skill)), x, y, Renderer.color_text, true);
+      y += 12;
+      if (Client.getShowXpPerHour()[current_skill]) {
+          Renderer.drawShadowText(
+              g,
+              "XP/Hr: " + formatXP(Client.getXpPerHour()[current_skill]),
+              x,
+              y,
+              Renderer.color_text,
+              true);
+          y += 12;
+      }
+
+      y += 8;
+
+
+      if (!post99xp) {
+          Renderer.drawShadowText(
+              g,
+              "XP until Level: " + formatXP(Client.getXPUntilLevel(current_skill)),
+              x,
+              y,
+              Renderer.color_text,
+              true);
+          y += 12;
+          if (Client.getShowXpPerHour()[current_skill]) {
+              Renderer.drawShadowText(
+                  g,
+                  "Actions until Level: "
+                      + formatXP(Client.getXPUntilLevel(current_skill) / Client.getLastXpGain(current_skill)),
+                  x,
+                  y,
+                  Renderer.color_text,
+                  true);
+              y += 12;
+          }
+          y += 8;
+      }
+
+      if (hasGoalForSkill(current_skill)) {
+          Renderer.drawShadowText(
+              g,
+              "XP until Goal: " + formatXP(Client.getXPUntilGoal(current_skill)),
+              x,
+              y,
+              Renderer.color_text,
+              true);
+          y += 12;
+          if (Client.getShowXpPerHour()[current_skill]) {
+              Renderer.drawShadowText(
+                  g,
+                  "Actions until Goal: "
+                      + formatXP(Client.getXPUntilGoal(current_skill) / Client.getLastXpGain(current_skill)),
+                  x,
+                  y,
+                  Renderer.color_text,
+                  true);
+              y += 12;
+          }
+          Renderer.drawShadowText(
+              g,
+              "Current Goal Level: " + Client.lvlGoals.get(Client.xpUsername)[current_skill],
+              x,
+              y,
+              Renderer.color_text,
+              true);
+          y += 12;
+          y += 8;
+      }
+      Renderer.drawShadowText(
+          g,
+          "Right-click for more options",
+          x,
+          y,
+          Renderer.color_text,
+          true);
+  }
+
+  public static boolean hasGoalForSkill(int skill) {
+      try {
+          return Client.xpGoals.get(Client.xpUsername)[skill] > 0;
+      } catch (Exception e) {
+          return false;
+      }
   }
 
   /**


### PR DESCRIPTION
New features:
- Ability to pin XP bar permanently on screen (persists over client loads)
- Ability to pin specific skill permanently (persists over client loads)
- Ability to set arbitrary XP goals per skill (persists over client loads)
- Recognition of separate user accounts (all features are per account, other than whether or not UI is pinned & which skill)
- Ability to reset when the beginning of an XP gaining session is, for the purpose of more accurate XP/hr
- Right click menu to control new XP bar features

Bug fixes:
- Actions to Level seemed to be broken, now it is not
- No longer get massive XP drops when first logging in
- Switching accounts no longer gives massive XP drops
- XP/hr tracking no longer resets after 3 minutes of skill inactivity
- XP Drops now occur even if an interface is open (no more grouping up of XP drops)
- Fixed bug consuming mousepress while in replay playback mode & player controls not shown but player bar is shown

Possible improvements:
- Ability to change XP progress bar between Level & Goal mode (currently stuck in Level mode, but could add another right-click menu option for this)
- Ability to change colour of XP progress bar to user's favourite colour, or depending on percent progress
- Could offer per-account preferred skill pin
- Could maybe space the right-click menu out a bit more
- Maybe if an XP Level goal ends up being a round Level (e.g. 70.0), it should just say 70 instead of 70.0
- Indicate how long the session has elapsed
- Option to permanently stick the hover-menu somewhere on screen (top right corner while interfaces are closed?)
- Make sure not to reset entire XP session on log out
- Hours/Minutes to next level / goal
- play Level Advance sound if reaching goal & goal level is not already on a level boundary
- Can also put green message "Congratulations, you reached xxxxx XP!"