### PR TITLE
Enable display of server types and softreload when changing between them

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -18,12 +18,6 @@
  */
 package Client;
 
-import Client.KeybindSet.KeyModifier;
-import Game.Camera;
-import Game.Client;
-import Game.Game;
-import Game.KeyboardHandler;
-import Game.Replay;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -82,6 +76,12 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.nimbus.NimbusLookAndFeel;
+import Client.KeybindSet.KeyModifier;
+import Game.Camera;
+import Game.Client;
+import Game.Game;
+import Game.KeyboardHandler;
+import Game.Replay;
 
 /**
  * GUI designed for the RSCPlus client that manages configuration options and keybind values from
@@ -256,6 +256,7 @@ public class ConfigWindow {
 
   //// World List tab
   private HashMap<Integer, JTextField> worldNamesJTextFields = new HashMap<Integer, JTextField>();
+  private HashMap<Integer, JTextField> worldTypesJTextFields = new HashMap<Integer, JTextField>();
   private HashMap<Integer, JButton> worldDeleteJButtons = new HashMap<Integer, JButton>();
   private HashMap<Integer, JTextField> worldUrlsJTextFields = new HashMap<Integer, JTextField>();
   private HashMap<Integer, JTextField> worldPortsJTextFields = new HashMap<Integer, JTextField>();
@@ -2653,6 +2654,13 @@ public class ConfigWindow {
       Settings.WORLD_NAMES.put(
           i, getTextWithDefault(worldNamesJTextFields, i, String.format("World %d", i)));
       Settings.WORLD_URLS.put(i, worldUrlsJTextFields.get(i).getText());
+      
+      String serverTypeString = worldTypesJTextFields.get(i).getText();
+      if (serverTypeString.equals("")) {
+          Settings.WORLD_SERVER_TYPES.put(i, 1);
+        } else {
+          Settings.WORLD_PORTS.put(i, Integer.parseInt(serverTypeString));
+        }
 
       String portString = worldPortsJTextFields.get(i).getText();
       if (portString.equals("")) {
@@ -2751,6 +2759,20 @@ public class ConfigWindow {
     worldNamesJTextFields.get(i).setPreferredSize(new Dimension(200, 28));
     worldNamesJTextFields.get(i).setAlignmentY((float) 0.75);
     worldListTitleTextFieldContainers.get(i).add(worldNamesJTextFields.get(i), cR);
+    
+    cR.weightx = 0.2;
+    cR.gridwidth = 2;
+    
+    JLabel worldTypeJLabel = new JLabel(String.format("<html><b>ServerType</b></html>", i));
+    worldNumberJLabel.setAlignmentY((float) 0.75);
+    worldListTitleTextFieldContainers.get(i).add(worldTypeJLabel, cR);
+
+    worldTypesJTextFields.put(i, new HintTextField("Type of World"));
+    worldTypesJTextFields.get(i).setMinimumSize(new Dimension(80, 28));
+    worldTypesJTextFields.get(i).setMaximumSize(new Dimension(120, 28));
+    worldTypesJTextFields.get(i).setPreferredSize(new Dimension(100, 28));
+    worldTypesJTextFields.get(i).setAlignmentY((float) 0.75);
+    worldListTitleTextFieldContainers.get(i).add(worldTypesJTextFields.get(i), cR);
 
     cR.weightx = 0.3;
     cR.gridwidth = 1;
@@ -2879,6 +2901,7 @@ public class ConfigWindow {
     for (int i = 1; (i <= numberOfWorldsEver) || (i <= Settings.WORLDS_TO_DISPLAY); i++) {
       if (i <= Settings.WORLDS_TO_DISPLAY) {
         worldNamesJTextFields.get(i).setText(Settings.WORLD_NAMES.get(i));
+        worldTypesJTextFields.get(i).setText("" + Settings.WORLD_SERVER_TYPES.getOrDefault(i, 1));
         worldUrlsJTextFields.get(i).setText(Settings.WORLD_URLS.get(i));
         try {
           worldPortsJTextFields.get(i).setText(Settings.WORLD_PORTS.get(i).toString());

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -18,6 +18,12 @@
  */
 package Client;
 
+import Client.KeybindSet.KeyModifier;
+import Game.Camera;
+import Game.Client;
+import Game.Game;
+import Game.KeyboardHandler;
+import Game.Replay;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -76,12 +82,6 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.nimbus.NimbusLookAndFeel;
-import Client.KeybindSet.KeyModifier;
-import Game.Camera;
-import Game.Client;
-import Game.Game;
-import Game.KeyboardHandler;
-import Game.Replay;
 
 /**
  * GUI designed for the RSCPlus client that manages configuration options and keybind values from
@@ -2654,13 +2654,13 @@ public class ConfigWindow {
       Settings.WORLD_NAMES.put(
           i, getTextWithDefault(worldNamesJTextFields, i, String.format("World %d", i)));
       Settings.WORLD_URLS.put(i, worldUrlsJTextFields.get(i).getText());
-      
+
       String serverTypeString = worldTypesJTextFields.get(i).getText();
       if (serverTypeString.equals("")) {
-          Settings.WORLD_SERVER_TYPES.put(i, 1);
-        } else {
-          Settings.WORLD_PORTS.put(i, Integer.parseInt(serverTypeString));
-        }
+        Settings.WORLD_SERVER_TYPES.put(i, 1);
+      } else {
+        Settings.WORLD_PORTS.put(i, Integer.parseInt(serverTypeString));
+      }
 
       String portString = worldPortsJTextFields.get(i).getText();
       if (portString.equals("")) {
@@ -2759,10 +2759,10 @@ public class ConfigWindow {
     worldNamesJTextFields.get(i).setPreferredSize(new Dimension(200, 28));
     worldNamesJTextFields.get(i).setAlignmentY((float) 0.75);
     worldListTitleTextFieldContainers.get(i).add(worldNamesJTextFields.get(i), cR);
-    
+
     cR.weightx = 0.2;
     cR.gridwidth = 2;
-    
+
     JLabel worldTypeJLabel = new JLabel(String.format("<html><b>ServerType</b></html>", i));
     worldNumberJLabel.setAlignmentY((float) 0.75);
     worldListTitleTextFieldContainers.get(i).add(worldTypeJLabel, cR);

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1744,7 +1744,7 @@ public class ConfigWindow {
     replayPanelShowConversionSettingsCheckbox.setToolTipText(
         "Chat Stripping, Private Chat Stripping, Whether or not it has been converted, etc.");
     replayPanelShowUserFieldCheckbox =
-        addCheckbox("Show \"User Field\" Column (Most likely unused)", replayPanel);
+        addCheckbox("Show \"User Field\" Column (1st bit used for F2P)", replayPanel);
     replayPanelShowUserFieldCheckbox.setToolTipText(
         "This int field when introduced did absolutely nothing and acts as \"Reserved Bits\" for the metadata.bin format. Users may feel free to use it for whatever they can think of.");
 

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -48,36 +48,10 @@ import java.awt.event.KeyListener;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Hashtable;
+import java.util.*;
 import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPasswordField;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSeparator;
-import javax.swing.JSlider;
-import javax.swing.JSpinner;
-import javax.swing.JTabbedPane;
-import javax.swing.JTextField;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
-import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -256,7 +230,7 @@ public class ConfigWindow {
 
   //// World List tab
   private HashMap<Integer, JTextField> worldNamesJTextFields = new HashMap<Integer, JTextField>();
-  private HashMap<Integer, JTextField> worldTypesJTextFields = new HashMap<Integer, JTextField>();
+  private HashMap<Integer, JComboBox> worldTypesJComboBoxes = new HashMap<Integer, JComboBox>();
   private HashMap<Integer, JButton> worldDeleteJButtons = new HashMap<Integer, JButton>();
   private HashMap<Integer, JTextField> worldUrlsJTextFields = new HashMap<Integer, JTextField>();
   private HashMap<Integer, JTextField> worldPortsJTextFields = new HashMap<Integer, JTextField>();
@@ -2655,12 +2629,7 @@ public class ConfigWindow {
           i, getTextWithDefault(worldNamesJTextFields, i, String.format("World %d", i)));
       Settings.WORLD_URLS.put(i, worldUrlsJTextFields.get(i).getText());
 
-      String serverTypeString = worldTypesJTextFields.get(i).getText();
-      if (serverTypeString.equals("")) {
-        Settings.WORLD_SERVER_TYPES.put(i, 1);
-      } else {
-        Settings.WORLD_PORTS.put(i, Integer.parseInt(serverTypeString));
-      }
+      Settings.WORLD_SERVER_TYPES.put(i, (Integer) worldTypesJComboBoxes.get(i).getSelectedIndex());
 
       String portString = worldPortsJTextFields.get(i).getText();
       if (portString.equals("")) {
@@ -2760,31 +2729,34 @@ public class ConfigWindow {
     worldNamesJTextFields.get(i).setAlignmentY((float) 0.75);
     worldListTitleTextFieldContainers.get(i).add(worldNamesJTextFields.get(i), cR);
 
-    cR.weightx = 0.2;
-    cR.gridwidth = 2;
-
-    JLabel worldTypeJLabel = new JLabel(String.format("<html><b>ServerType</b></html>", i));
-    worldNumberJLabel.setAlignmentY((float) 0.75);
-    worldListTitleTextFieldContainers.get(i).add(worldTypeJLabel, cR);
-
-    worldTypesJTextFields.put(i, new HintTextField("Type of World"));
-    worldTypesJTextFields.get(i).setMinimumSize(new Dimension(80, 28));
-    worldTypesJTextFields.get(i).setMaximumSize(new Dimension(120, 28));
-    worldTypesJTextFields.get(i).setPreferredSize(new Dimension(100, 28));
-    worldTypesJTextFields.get(i).setAlignmentY((float) 0.75);
-    worldListTitleTextFieldContainers.get(i).add(worldTypesJTextFields.get(i), cR);
-
-    cR.weightx = 0.3;
+    cR.weightx = 0.1;
     cR.gridwidth = 1;
     cR.anchor = GridBagConstraints.LINE_END;
 
-    JLabel spacingJLabel = new JLabel("");
-    worldNumberJLabel.setAlignmentY((float) 0.75);
-    worldListTitleTextFieldContainers.get(i).add(spacingJLabel, cR);
+    /*
+          JLabel spacingJLabel = new JLabel("");
+          worldNumberJLabel.setAlignmentY((float) 0.75);
+          worldListTitleTextFieldContainers.get(i).add(spacingJLabel, cR);
+    */
+
+    String[] worldTypes = {"F2P", "Members", "F2P (Veteran)", "Members (Veteran)"};
+    JComboBox worldTypeComboBox = new JComboBox(worldTypes);
+
+    worldTypesJComboBoxes.put(i, worldTypeComboBox);
+    worldTypesJComboBoxes.get(i).setMinimumSize(new Dimension(120, 28));
+    worldTypesJComboBoxes.get(i).setMaximumSize(new Dimension(120, 28));
+    worldTypesJComboBoxes.get(i).setPreferredSize(new Dimension(120, 28));
+    worldTypesJComboBoxes.get(i).setAlignmentY((float) 0.75);
+    worldListTitleTextFieldContainers.get(i).add(worldTypesJComboBoxes.get(i), cR);
+
+    cR.weightx = 0.3;
+    cR.gridwidth = 1;
 
     worldDeleteJButtons.put(i, new JButton("Delete World"));
     worldDeleteJButtons.get(i).setAlignmentY((float) 0.80);
     worldDeleteJButtons.get(i).setPreferredSize(new Dimension(50, 28));
+    worldTypesJComboBoxes.get(i).setMinimumSize(new Dimension(50, 28));
+    worldTypesJComboBoxes.get(i).setMaximumSize(new Dimension(50, 28));
     worldDeleteJButtons.get(i).setActionCommand(String.format("%d", i));
     worldDeleteJButtons
         .get(i)
@@ -2901,7 +2873,9 @@ public class ConfigWindow {
     for (int i = 1; (i <= numberOfWorldsEver) || (i <= Settings.WORLDS_TO_DISPLAY); i++) {
       if (i <= Settings.WORLDS_TO_DISPLAY) {
         worldNamesJTextFields.get(i).setText(Settings.WORLD_NAMES.get(i));
-        worldTypesJTextFields.get(i).setText("" + Settings.WORLD_SERVER_TYPES.getOrDefault(i, 1));
+        worldTypesJComboBoxes
+            .get(i)
+            .setSelectedIndex(Settings.WORLD_SERVER_TYPES.getOrDefault(i, 1));
         worldUrlsJTextFields.get(i).setText(Settings.WORLD_URLS.get(i));
         try {
           worldPortsJTextFields.get(i).setText(Settings.WORLD_PORTS.get(i).toString());

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -48,10 +48,37 @@ import java.awt.event.KeyListener;
 import java.awt.image.BufferedImage;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Hashtable;
 import javax.imageio.ImageIO;
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -2739,7 +2766,7 @@ public class ConfigWindow {
           worldListTitleTextFieldContainers.get(i).add(spacingJLabel, cR);
     */
 
-    String[] worldTypes = {"F2P", "Members", "F2P (Veteran)", "Members (Veteran)"};
+    String[] worldTypes = {"Free", "Members", "Free (Veteran)", "Members (Veteran)"};
     JComboBox worldTypeComboBox = new JComboBox(worldTypes);
 
     worldTypesJComboBoxes.put(i, worldTypeComboBox);

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -830,6 +830,9 @@ public class JClassPatcher {
               "Ljava/lang/Object;",
               true,
               false);
+      
+      hookClassVariable(
+              methodNode, "client", "yj", "I", "Game/Client", "lastHeightOffset", "I", true, true);
     }
   }
 

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -18,6 +18,7 @@
  */
 package Client;
 
+import Client.Settings.Dir;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -47,7 +48,6 @@ import org.objectweb.asm.tree.VarInsnNode;
 import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceMethodVisitor;
-import Client.Settings.Dir;
 
 /** Singleton class which hooks variables and patches classes. */
 public class JClassPatcher {
@@ -813,26 +813,25 @@ public class JClassPatcher {
 
       hookClassVariable(
           methodNode, "client", "Cf", "I", "Game/Client", "mouse_click", "I", true, true);
-      
+
+      hookClassVariable(methodNode, "client", "Pg", "Z", "Game/Client", "members", "Z", true, true);
+
       hookClassVariable(
-              methodNode, "client", "Pg", "Z", "Game/Client", "members", "Z", true, true);
-      
+          methodNode, "client", "cf", "Z", "Game/Client", "veterans", "Z", true, true);
+
       hookClassVariable(
-              methodNode, "client", "cf", "Z", "Game/Client", "veterans", "Z", true, true);
-      
+          methodNode,
+          "client",
+          "Hh",
+          "Lk;",
+          "Game/Client",
+          "worldInstance",
+          "Ljava/lang/Object;",
+          true,
+          false);
+
       hookClassVariable(
-              methodNode,
-              "client",
-              "Hh",
-              "Lk;",
-              "Game/Client",
-              "worldInstance",
-              "Ljava/lang/Object;",
-              true,
-              false);
-      
-      hookClassVariable(
-              methodNode, "client", "yj", "I", "Game/Client", "lastHeightOffset", "I", true, true);
+          methodNode, "client", "yj", "I", "Game/Client", "lastHeightOffset", "I", true, true);
     }
   }
 
@@ -2772,7 +2771,7 @@ public class JClassPatcher {
             break;
           }
         }
-        
+
         // Add text if server is free and non veterans
         insnNodeList = methodNode.instructions.iterator();
 
@@ -2786,22 +2785,23 @@ public class JClassPatcher {
           if (insnNode.getOpcode() == Opcodes.ACONST_NULL
               && nextNode.getOpcode() == Opcodes.ALOAD
               && ((VarInsnNode) nextNode).var == 3) {
-        	  call = insnNode;
-        	  
-        	  LabelNode label = new LabelNode();
+            call = insnNode;
 
-        	  methodNode.instructions.insertBefore(call, new VarInsnNode(Opcodes.ALOAD, 0));
-        	  methodNode.instructions.insertBefore(
-        			  call, new FieldInsnNode(Opcodes.GETFIELD, "client", "Pg", "Z"));
-              methodNode.instructions.insertBefore(call, new JumpInsnNode(Opcodes.IFNE, label));
-              methodNode.instructions.insertBefore(call, new LdcInsnNode("You need an account to use this server"));
-              methodNode.instructions.insertBefore(call, new VarInsnNode(Opcodes.ASTORE, 3));
-              methodNode.instructions.insertBefore(call, label);
-                      	  
-        	  break;
+            LabelNode label = new LabelNode();
+
+            methodNode.instructions.insertBefore(call, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(
+                call, new FieldInsnNode(Opcodes.GETFIELD, "client", "Pg", "Z"));
+            methodNode.instructions.insertBefore(call, new JumpInsnNode(Opcodes.IFNE, label));
+            methodNode.instructions.insertBefore(
+                call, new LdcInsnNode("You need an account to use this server"));
+            methodNode.instructions.insertBefore(call, new VarInsnNode(Opcodes.ASTORE, 3));
+            methodNode.instructions.insertBefore(call, label);
+
+            break;
           }
         }
-        
+
         // Hook reference of control text of server type
         insnNodeList = methodNode.instructions.iterator();
 
@@ -2811,22 +2811,21 @@ public class JClassPatcher {
           AbstractInsnNode call;
 
           if (insnNode.getOpcode() == Opcodes.ACONST_NULL) {
-        	  
-        	  targetNode = insnNode;
-              while (targetNode.getOpcode() != Opcodes.INVOKEVIRTUAL
-                  || !((MethodInsnNode) targetNode).desc.equals("(ZBIILjava/lang/String;I)I")) {
-                // find the method of addText
-                targetNode = targetNode.getNext();
-              }
+
+            targetNode = insnNode;
+            while (targetNode.getOpcode() != Opcodes.INVOKEVIRTUAL
+                || !((MethodInsnNode) targetNode).desc.equals("(ZBIILjava/lang/String;I)I")) {
+              // find the method of addText
               targetNode = targetNode.getNext();
-              
-              methodNode.instructions.insert(
-                      targetNode,
-                      new FieldInsnNode(
-                          Opcodes.PUTSTATIC, "Game/Client", "controlServerType", "I"));
-              methodNode.instructions.insertBefore(targetNode, new IntInsnNode(Opcodes.BIPUSH, 0));
-                      	  
-        	  break;
+            }
+            targetNode = targetNode.getNext();
+
+            methodNode.instructions.insert(
+                targetNode,
+                new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "controlServerType", "I"));
+            methodNode.instructions.insertBefore(targetNode, new IntInsnNode(Opcodes.BIPUSH, 0));
+
+            break;
           }
         }
       }

--- a/src/Client/JConfig.java
+++ b/src/Client/JConfig.java
@@ -18,6 +18,7 @@
  */
 package Client;
 
+import Game.Replay;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
@@ -26,7 +27,6 @@ import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import Game.Replay;
 
 /** Parses, stores, and retrieves values from a jav_config.ws file */
 public class JConfig {
@@ -173,7 +173,7 @@ public class JConfig {
     parameters.put("nodeid", "" + (5000 + world));
     // TODO: This might have meant veteran world
     // if (world == 1) parameters.put("servertype", "" + 3);
-    //parameters.put("servertype", "" + 1);
+    // parameters.put("servertype", "" + 1);
     int servertype = Settings.WORLD_SERVER_TYPES.getOrDefault(world, 1);
     parameters.put("servertype", "" + servertype);
 
@@ -193,13 +193,13 @@ public class JConfig {
     if (!curWorldURL.equals("")) {
       Settings.noWorldsConfigured = false;
     }
-    
+
     Game.Client.setServerType(servertype);
     boolean isMembers = (servertype & 1) != 0;
-    
+
     if (Game.Client.lastIsMembers != null && Game.Client.lastIsMembers != isMembers) {
-    	Game.Client.lastIsMembers = isMembers;
-    	Game.Client.softReloadCache(isMembers);
+      Game.Client.lastIsMembers = isMembers;
+      Game.Client.softReloadCache(isMembers);
     }
 
     // Update settings

--- a/src/Client/JConfig.java
+++ b/src/Client/JConfig.java
@@ -180,7 +180,7 @@ public class JConfig {
     // Set world URL & port
     String curWorldURL = Settings.WORLD_URLS.get(world);
     m_data.put("codebase", "http://" + curWorldURL + "/");
-    Replay.connection_port = Settings.WORLD_PORTS.get(world);
+    Replay.connection_port = Settings.WORLD_PORTS.getOrDefault(world, Replay.DEFAULT_PORT);
     SERVER_RSA_EXPONENT = Settings.WORLD_RSA_EXPONENTS.get(world);
     SERVER_RSA_MODULUS = Settings.WORLD_RSA_PUB_KEYS.get(world);
     if (SERVER_RSA_EXPONENT.equals("")) {

--- a/src/Client/JConfig.java
+++ b/src/Client/JConfig.java
@@ -18,7 +18,6 @@
  */
 package Client;
 
-import Game.Replay;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.InetAddress;
@@ -27,6 +26,7 @@ import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import Game.Replay;
 
 /** Parses, stores, and retrieves values from a jav_config.ws file */
 public class JConfig {
@@ -173,7 +173,9 @@ public class JConfig {
     parameters.put("nodeid", "" + (5000 + world));
     // TODO: This might have meant veteran world
     // if (world == 1) parameters.put("servertype", "" + 3);
-    parameters.put("servertype", "" + 1);
+    //parameters.put("servertype", "" + 1);
+    int servertype = Settings.WORLD_SERVER_TYPES.getOrDefault(world, 1);
+    parameters.put("servertype", "" + servertype);
 
     // Set world URL & port
     String curWorldURL = Settings.WORLD_URLS.get(world);
@@ -190,6 +192,14 @@ public class JConfig {
 
     if (!curWorldURL.equals("")) {
       Settings.noWorldsConfigured = false;
+    }
+    
+    Game.Client.setServerType(servertype);
+    boolean isMembers = (servertype & 1) != 0;
+    
+    if (Game.Client.lastIsMembers != null && Game.Client.lastIsMembers != isMembers) {
+    	Game.Client.lastIsMembers = isMembers;
+    	Game.Client.softReloadCache(isMembers);
     }
 
     // Update settings

--- a/src/Client/JConfig.java
+++ b/src/Client/JConfig.java
@@ -194,7 +194,7 @@ public class JConfig {
       Settings.noWorldsConfigured = false;
     }
 
-    Game.Client.setServerType(servertype);
+    Game.Client.setServertype(servertype, true);
     boolean isMembers = (servertype & 1) != 0;
 
     if (Game.Client.lastIsMembers != null && Game.Client.lastIsMembers != isMembers) {

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -18,8 +18,6 @@
  */
 package Client;
 
-import Game.Client;
-import Game.Game;
 import java.applet.Applet;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -34,6 +32,8 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
+import Game.Client;
+import Game.Game;
 
 /** Singleton main class which renders a loading window and the game client window. */
 public class Launcher extends JFrame implements Runnable {
@@ -369,8 +369,12 @@ public class Launcher extends JFrame implements Runnable {
 
     Logger.Info("Loading resource: " + fileName);
 
-    if (fileName.equals("/assets/content/content10_ffffffffa95e7195")) {
+    if (fileName.equals("/assets/content/content10_ffffffffa95e7195") && Client.firstTime) {
+    	// members
       finishedLoading();
+    } else if (fileName.equals("/assets/content/content6_ffffffffe997514b") && !Client.members && Client.firstTime) {
+    	// free
+    	finishedLoading();
     }
 
     return url;
@@ -405,7 +409,11 @@ public class Launcher extends JFrame implements Runnable {
 
   public static void finishedLoading() {
     // Remember world setting
+	Client.lastIsMembers = Client.members;
     Game.getInstance().getJConfig().changeWorld(Settings.WORLD.get(Settings.currentProfile));
+    if (Client.firstTime) {
+    	Client.firstTime = false;
+    }
   }
 
   /** @return the window */

--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -18,6 +18,8 @@
  */
 package Client;
 
+import Game.Client;
+import Game.Game;
 import java.applet.Applet;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -32,8 +34,6 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
-import Game.Client;
-import Game.Game;
 
 /** Singleton main class which renders a loading window and the game client window. */
 public class Launcher extends JFrame implements Runnable {
@@ -370,11 +370,13 @@ public class Launcher extends JFrame implements Runnable {
     Logger.Info("Loading resource: " + fileName);
 
     if (fileName.equals("/assets/content/content10_ffffffffa95e7195") && Client.firstTime) {
-    	// members
+      // members
       finishedLoading();
-    } else if (fileName.equals("/assets/content/content6_ffffffffe997514b") && !Client.members && Client.firstTime) {
-    	// free
-    	finishedLoading();
+    } else if (fileName.equals("/assets/content/content6_ffffffffe997514b")
+        && !Client.members
+        && Client.firstTime) {
+      // free
+      finishedLoading();
     }
 
     return url;
@@ -409,10 +411,10 @@ public class Launcher extends JFrame implements Runnable {
 
   public static void finishedLoading() {
     // Remember world setting
-	Client.lastIsMembers = Client.members;
+    Client.lastIsMembers = Client.members;
     Game.getInstance().getJConfig().changeWorld(Settings.WORLD.get(Settings.currentProfile));
     if (Client.firstTime) {
-    	Client.firstTime = false;
+      Client.firstTime = false;
     }
   }
 

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -18,6 +18,13 @@
  */
 package Client;
 
+import Client.KeybindSet.KeyModifier;
+import Game.Camera;
+import Game.Client;
+import Game.Game;
+import Game.KeyboardHandler;
+import Game.Renderer;
+import Game.Replay;
 import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
@@ -29,13 +36,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Properties;
-import Client.KeybindSet.KeyModifier;
-import Game.Camera;
-import Game.Client;
-import Game.Game;
-import Game.KeyboardHandler;
-import Game.Renderer;
-import Game.Replay;
 
 /** Manages storing, loading, and changing settings. */
 public class Settings {
@@ -1420,7 +1420,8 @@ public class Settings {
             WORLD_NAMES.put(i, worldProps.getProperty("name"));
             WORLD_URLS.put(i, worldProps.getProperty("url"));
             WORLD_PORTS.put(i, Integer.parseInt(worldProps.getProperty("port")));
-            WORLD_SERVER_TYPES.put(i, Integer.parseInt((String)worldProps.getOrDefault("servertype", "1")));
+            WORLD_SERVER_TYPES.put(
+                i, Integer.parseInt((String) worldProps.getOrDefault("servertype", "1")));
             WORLD_RSA_PUB_KEYS.put(i, worldProps.getProperty("rsa_pub_key"));
             WORLD_RSA_EXPONENTS.put(i, worldProps.getProperty("rsa_exponent"));
 

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -18,13 +18,6 @@
  */
 package Client;
 
-import Client.KeybindSet.KeyModifier;
-import Game.Camera;
-import Game.Client;
-import Game.Game;
-import Game.KeyboardHandler;
-import Game.Renderer;
-import Game.Replay;
 import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
@@ -36,6 +29,13 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Properties;
+import Client.KeybindSet.KeyModifier;
+import Game.Camera;
+import Game.Client;
+import Game.Game;
+import Game.KeyboardHandler;
+import Game.Renderer;
+import Game.Replay;
 
 /** Manages storing, loading, and changing settings. */
 public class Settings {
@@ -190,6 +190,7 @@ public class Settings {
   public static HashMap<Integer, String> WORLD_URLS = new HashMap<Integer, String>();
   public static HashMap<Integer, String> WORLD_NAMES = new HashMap<Integer, String>();
   public static HashMap<Integer, Integer> WORLD_PORTS = new HashMap<Integer, Integer>();
+  public static HashMap<Integer, Integer> WORLD_SERVER_TYPES = new HashMap<Integer, Integer>();
   public static HashMap<Integer, String> WORLD_RSA_PUB_KEYS = new HashMap<Integer, String>();
   public static HashMap<Integer, String> WORLD_RSA_EXPONENTS = new HashMap<Integer, String>();
   public static HashMap<Integer, String> WORLD_FILE_PATHS = new HashMap<Integer, String>();
@@ -1419,6 +1420,7 @@ public class Settings {
             WORLD_NAMES.put(i, worldProps.getProperty("name"));
             WORLD_URLS.put(i, worldProps.getProperty("url"));
             WORLD_PORTS.put(i, Integer.parseInt(worldProps.getProperty("port")));
+            WORLD_SERVER_TYPES.put(i, Integer.parseInt((String)worldProps.getOrDefault("servertype", "1")));
             WORLD_RSA_PUB_KEYS.put(i, worldProps.getProperty("rsa_pub_key"));
             WORLD_RSA_EXPONENTS.put(i, worldProps.getProperty("rsa_exponent"));
 
@@ -1449,6 +1451,7 @@ public class Settings {
       worldProps.setProperty("name", WORLD_NAMES.get(i));
       worldProps.setProperty("url", WORLD_URLS.get(i));
       worldProps.setProperty("port", WORLD_PORTS.get(i).toString());
+      worldProps.setProperty("servertype", WORLD_SERVER_TYPES.get(i).toString());
       worldProps.setProperty("rsa_pub_key", WORLD_RSA_PUB_KEYS.get(i));
       worldProps.setProperty("rsa_exponent", WORLD_RSA_EXPONENTS.get(i));
 
@@ -1478,6 +1481,7 @@ public class Settings {
     WORLD_NAMES.put(worldNum, String.format("World %d", worldNum));
     WORLD_URLS.put(worldNum, "");
     WORLD_PORTS.put(worldNum, Replay.DEFAULT_PORT);
+    WORLD_SERVER_TYPES.put(worldNum, 1);
     WORLD_RSA_PUB_KEYS.put(worldNum, "");
     WORLD_RSA_EXPONENTS.put(worldNum, "");
 
@@ -1489,6 +1493,7 @@ public class Settings {
     worldProps.setProperty("name", WORLD_NAMES.get(worldNum));
     worldProps.setProperty("url", WORLD_URLS.get(worldNum));
     worldProps.setProperty("port", WORLD_PORTS.get(worldNum).toString());
+    worldProps.setProperty("servertype", WORLD_SERVER_TYPES.get(worldNum).toString());
     worldProps.setProperty("rsa_pub_key", WORLD_RSA_PUB_KEYS.get(worldNum));
     worldProps.setProperty("rsa_exponent", WORLD_RSA_EXPONENTS.get(worldNum));
 
@@ -1517,6 +1522,7 @@ public class Settings {
       WORLD_NAMES.put(i - 1, WORLD_NAMES.remove(i));
       WORLD_URLS.put(i - 1, WORLD_URLS.remove(i));
       WORLD_PORTS.put(i - 1, WORLD_PORTS.remove(i));
+      WORLD_SERVER_TYPES.put(i - 1, WORLD_SERVER_TYPES.remove(i));
       WORLD_RSA_PUB_KEYS.put(i - 1, WORLD_RSA_PUB_KEYS.remove(i));
       WORLD_RSA_EXPONENTS.put(i - 1, WORLD_RSA_EXPONENTS.remove(i));
       WORLD_FILE_PATHS.put(i - 1, WORLD_FILE_PATHS.remove(i));
@@ -1524,6 +1530,7 @@ public class Settings {
     WORLD_NAMES.remove(initialSize);
     WORLD_URLS.remove(initialSize);
     WORLD_PORTS.remove(initialSize);
+    WORLD_SERVER_TYPES.remove(initialSize);
     WORLD_RSA_PUB_KEYS.remove(initialSize);
     WORLD_RSA_EXPONENTS.remove(initialSize);
     WORLD_FILE_PATHS.remove(initialSize);

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -367,6 +367,7 @@ public class Client {
   public static boolean members;
   public static boolean veterans;
   public static Object worldInstance;
+  public static int lastHeightOffset;
   
   public static Boolean lastIsMembers = null;
 
@@ -1500,6 +1501,10 @@ public class Client {
 		  Reflection.loadMaps.invoke(Client.instance, 5359);
 		  if (members) {
 			  Reflection.loadSounds.invoke(Client.instance, -90);
+		  }
+		  if (lastHeightOffset == planeIndex) {
+			  // force re-render of game world terrain
+			  lastHeightOffset = (planeIndex + 1) % 2;
 		  }
 	  } catch(Exception e) {  
 	  }

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -365,12 +365,17 @@ public class Client {
 
   public static int mouse_click;
   public static boolean firstTime = true;
-  public static boolean members;
-  public static boolean veterans;
   public static Object worldInstance;
   public static int lastHeightOffset;
 
   public static Boolean lastIsMembers = null;
+
+  // used in original client
+  public static boolean members;
+  public static boolean veterans;
+  // used to distinguish live world, in replay there are two similar variables
+  public static boolean worldMembers;
+  public static boolean worldVeterans;
 
   /**
    * Iterates through {@link #strings} array and checks if various conditions are met. Used for
@@ -1560,6 +1565,27 @@ public class Client {
       }
     } catch (Exception e) {
 
+    }
+  }
+
+  /**
+   * Switches direction of live game to replay. True - to change to replay. False - to change to
+   * live
+   */
+  public static void switchLiveToReplay(boolean direction) {
+    int currentType = (Client.veterans ? 1 : 0 << 1) + (Client.members ? 1 : 0);
+    int serverType;
+    if (direction) {
+      serverType = (Replay.replayVeterans ? 1 : 0 << 1) + (Replay.replayMembers ? 1 : 0);
+    } else {
+      serverType = (Client.worldVeterans ? 1 : 0 << 1) + (Client.worldMembers ? 1 : 0);
+    }
+
+    if (currentType != serverType) {
+      Client.setServerType(serverType);
+      if ((serverType & 1) != (currentType & 1)) {
+        Client.softReloadCache((serverType & 1) != 0);
+      }
     }
   }
 

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -19,6 +19,18 @@
 package Game;
 
 import static Replay.game.constants.Game.itemActionMap;
+
+import Client.JClassPatcher;
+import Client.JConfig;
+import Client.KeybindSet;
+import Client.Launcher;
+import Client.Logger;
+import Client.NotificationsHandler;
+import Client.NotificationsHandler.NotifType;
+import Client.Settings;
+import Client.Speedrun;
+import Client.TwitchIRC;
+import Replay.game.constants.Game.ItemAction;
 import java.applet.Applet;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -40,17 +52,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.swing.JOptionPane;
-import Client.JClassPatcher;
-import Client.JConfig;
-import Client.KeybindSet;
-import Client.Launcher;
-import Client.Logger;
-import Client.NotificationsHandler;
-import Client.NotificationsHandler.NotifType;
-import Client.Settings;
-import Client.Speedrun;
-import Client.TwitchIRC;
-import Replay.game.constants.Game.ItemAction;
 
 /**
  * This class prepares the client for login, handles chat messages, and performs player related
@@ -368,7 +369,7 @@ public class Client {
   public static boolean veterans;
   public static Object worldInstance;
   public static int lastHeightOffset;
-  
+
   public static Boolean lastIsMembers = null;
 
   /**
@@ -1455,59 +1456,60 @@ public class Client {
     } catch (Exception e) {
     }
   }
-  
-  /** Sets the account type needed in the welcome screen, based on the server type
-   *  0 = Free
-   *  1 = Members
-   *  2 = Free (Veterans)
-   *  3 = Members (Veterans)
-   *  */
+
+  /**
+   * Sets the account type needed in the welcome screen, based on the server type 0 = Free 1 =
+   * Members 2 = Free (Veterans) 3 = Members (Veterans)
+   */
   public static void setServerType(int servertype) {
-	  try {
-		  if ((servertype & 1) != 0) { //members
-			  Client.members = true;
-			  if ((servertype & 2) != 0) { //members + veterans
-				  // "You need a veteran Classic members account to use this server"
-				  Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[233]);
-				  Client.veterans = true;
-			  } else {
-				  // "You need a members account to use this server"
-				  Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[230]);
-				  Client.veterans = false;
-			  }
-		  } else { //free
-			  Client.members = false;
-			  if ((servertype & 2) != 0) { //free + veterans
-				  // "You need a veteran Classic account to use this server"
-				  Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[238]);
-				  Client.veterans = true;
-			  } else {
-				  // "You need an account to use this server"
-				  Panel.setControlText(Client.panelWelcome, Client.controlServerType, "You need an account to use this server");
-				  Client.veterans = false;
-			  }
-		  }
-	  } catch (Exception e) {
-	  }
+    try {
+      if ((servertype & 1) != 0) { // members
+        Client.members = true;
+        if ((servertype & 2) != 0) { // members + veterans
+          // "You need a veteran Classic members account to use this server"
+          Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[233]);
+          Client.veterans = true;
+        } else {
+          // "You need a members account to use this server"
+          Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[230]);
+          Client.veterans = false;
+        }
+      } else { // free
+        Client.members = false;
+        if ((servertype & 2) != 0) { // free + veterans
+          // "You need a veteran Classic account to use this server"
+          Panel.setControlText(Client.panelWelcome, Client.controlServerType, strings[238]);
+          Client.veterans = true;
+        } else {
+          // "You need an account to use this server"
+          Panel.setControlText(
+              Client.panelWelcome,
+              Client.controlServerType,
+              "You need an account to use this server");
+          Client.veterans = false;
+        }
+      }
+    } catch (Exception e) {
+    }
   }
-  
+
   public static void softReloadCache(boolean members) {
-	  try {
-		  Reflection.memberMapPack.set(Client.worldInstance, null);
-		  Reflection.memberLandscapePack.set(Client.worldInstance, null);
-		  
-		  Reflection.loadGameConfig.invoke(Client.instance, false);
-		  Reflection.loadEntities.invoke(Client.instance, true);
-		  Reflection.loadMaps.invoke(Client.instance, 5359);
-		  if (members) {
-			  Reflection.loadSounds.invoke(Client.instance, -90);
-		  }
-		  if (lastHeightOffset == planeIndex) {
-			  // force re-render of game world terrain
-			  lastHeightOffset = (planeIndex + 1) % 2;
-		  }
-	  } catch(Exception e) {  
-	  }
+    try {
+      Reflection.memberMapPack.set(Client.worldInstance, null);
+      Reflection.memberLandscapePack.set(Client.worldInstance, null);
+
+      Reflection.loadGameConfig.invoke(Client.instance, false);
+      Reflection.loadEntities.invoke(Client.instance, true);
+      Reflection.loadMaps.invoke(Client.instance, 5359);
+      if (members) {
+        Reflection.loadSounds.invoke(Client.instance, -90);
+      }
+      if (lastHeightOffset == planeIndex) {
+        // force re-render of game world terrain
+        lastHeightOffset = (planeIndex + 1) % 2;
+      }
+    } catch (Exception e) {
+    }
   }
 
   public static void closeConnection(boolean sendPacket31) {

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -1580,7 +1580,7 @@ public class Client {
    * Sets the account type needed in the welcome screen, based on the server type 0 = Free 1 =
    * Members 2 = Free (Veterans) 3 = Members (Veterans)
    */
-  public static void setServerType(int servertype) {
+  public static void setServertype(int servertype, boolean switchingWorld) {
     try {
       if ((servertype & 1) != 0) { // members
         Client.members = true;
@@ -1607,6 +1607,10 @@ public class Client {
               "You need an account to use this server");
           Client.veterans = false;
         }
+      }
+      if (switchingWorld) {
+          Client.worldMembers = Client.members;
+          Client.worldVeterans = Client.veterans;
       }
     } catch (Exception e) {
     }
@@ -1687,18 +1691,18 @@ public class Client {
    * live
    */
   public static void switchLiveToReplay(boolean direction) {
-    int currentType = (Client.veterans ? 1 : 0 << 1) + (Client.members ? 1 : 0);
-    int serverType;
+    int currentType = ((Client.veterans ? 1 : 0) << 1) + (Client.members ? 1 : 0);
+    int servertype;
     if (direction) {
-      serverType = (Replay.replayVeterans ? 1 : 0 << 1) + (Replay.replayMembers ? 1 : 0);
+      servertype = ((Replay.replayVeterans ? 1 : 0) << 1) + (Replay.replayMembers ? 1 : 0);
     } else {
-      serverType = (Client.worldVeterans ? 1 : 0 << 1) + (Client.worldMembers ? 1 : 0);
+      servertype = ((Client.worldVeterans ? 1 : 0) << 1) + (Client.worldMembers ? 1 : 0);
     }
 
-    if (currentType != serverType) {
-      Client.setServerType(serverType);
-      if ((serverType & 1) != (currentType & 1)) {
-        Client.softReloadCache((serverType & 1) != 0);
+    if (currentType != servertype) {
+      Client.setServertype(servertype, !direction);
+      if ((servertype & 1) != (currentType & 1)) {
+        Client.softReloadCache((servertype & 1) != 0);
       }
     }
   }

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -18,14 +18,14 @@
  */
 package Game;
 
-import Client.JClassLoader;
-import Client.Launcher;
-import Client.Logger;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import Client.JClassLoader;
+import Client.Launcher;
+import Client.Logger;
 
 /** Loads and sets fields and methods found in the vanilla RSC jar's classes */
 public class Reflection {
@@ -69,6 +69,10 @@ public class Reflection {
   public static Field menuTextSize = null;
   public static Field menuText = null;
   public static Field menuCount = null;
+  
+  public static Field memberMapPack = null;
+  public static Field memberLandscapePack = null;
+  public static Field memberSoundPack = null;
 
   public static Method showInputPopup = null;
   public static Method getParameter = null;
@@ -121,6 +125,11 @@ public class Reflection {
   public static Method resetTimings = null;
   public static Method formatText = null;
   public static Method putRandom = null;
+  
+  public static Method loadGameConfig = null;
+  public static Method loadEntities = null;
+  public static Method loadMaps = null;
+  public static Method loadSounds = null;
 
   public static Method addButtonBack = null;
   public static Method addCenterText = null;
@@ -203,6 +212,11 @@ public class Reflection {
   private static final String FORMAT_TEXT =
       "static final java.lang.String b.a(int,byte,java.lang.String)";
   private static final String PUTRANDOM = "static final void f.a(int,tb)";
+  
+  private static final String LOAD_GAME_CONFIG = "private final void client.f(boolean)";
+  private static final String LOAD_ENTITIES = "private final void client.c(boolean)";
+  private static final String LOAD_MAPS = "private final void client.m(int)";
+  private static final String LOAD_SOUNDS = "private final void client.E(int)";
 
   private static final String ADDBUTTONBACK = "final int qa.c(int,int,int,int,int)";
   private static final String ADDCENTERTEXT =
@@ -241,6 +255,7 @@ public class Reflection {
       // Client
       c = classLoader.loadClass("client");
       clientStreamField = c.getDeclaredField("Jh");
+      memberSoundPack = c.getDeclaredField("Uh");
       methods = c.getDeclaredMethods();
       for (Method method : methods) {
         if (method.toGenericString().equals(DISPLAYMESSAGE)) {
@@ -276,6 +291,18 @@ public class Reflection {
         } else if (method.toGenericString().equals(SHOW_INPUT_POPUP)) {
           showInputPopup = method;
           Logger.Info("Found showInputPopup");
+        } else if (method.toGenericString().equals(LOAD_GAME_CONFIG)) {
+        	loadGameConfig = method;
+        	Logger.Info("Found loadGameConfig");
+        } else if (method.toGenericString().equals(LOAD_ENTITIES)) {
+        	loadEntities = method;
+        	Logger.Info("Found loadEntities");
+        } else if (method.toGenericString().equals(LOAD_MAPS)) {
+        	loadMaps = method;
+        	Logger.Info("Found loadMaps");
+        } else if (method.toGenericString().equals(LOAD_SOUNDS)) {
+        	loadSounds = method;
+        	Logger.Info("Found loadSounds");
         }
       }
 
@@ -680,6 +707,19 @@ public class Reflection {
           Logger.Info("Found gameReference");
         }
       }
+      
+      c = classLoader.loadClass("k");
+      fields = c.getDeclaredFields();
+      for (Field field : fields) {
+        if (field.getName().equals("m")) {
+        	memberMapPack = field;
+          Logger.Info("Found memberMapPack");
+        }
+        if (field.getName().equals("I")) {
+        	memberLandscapePack = field;
+          Logger.Info("Found memberLandscapePack");
+        }
+      }
 
       // Set all accessible
       if (clientStreamField != null) clientStreamField.setAccessible(true);
@@ -765,6 +805,13 @@ public class Reflection {
       if (handleKey != null) handleKey.setAccessible(true);
       if (gameReference != null) gameReference.setAccessible(true);
       if (showInputPopup != null) showInputPopup.setAccessible(true);
+      if (loadGameConfig != null) loadGameConfig.setAccessible(true);
+      if (loadEntities != null) loadEntities.setAccessible(true);
+      if (loadMaps != null) loadMaps.setAccessible(true);
+      if (loadSounds != null) loadSounds.setAccessible(true);
+      if (memberMapPack != null) memberMapPack.setAccessible(true);
+      if (memberLandscapePack != null) memberLandscapePack.setAccessible(true);
+      if (memberSoundPack != null) memberSoundPack.setAccessible(true);
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -18,14 +18,14 @@
  */
 package Game;
 
+import Client.JClassLoader;
+import Client.Launcher;
+import Client.Logger;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import Client.JClassLoader;
-import Client.Launcher;
-import Client.Logger;
 
 /** Loads and sets fields and methods found in the vanilla RSC jar's classes */
 public class Reflection {
@@ -69,7 +69,7 @@ public class Reflection {
   public static Field menuTextSize = null;
   public static Field menuText = null;
   public static Field menuCount = null;
-  
+
   public static Field memberMapPack = null;
   public static Field memberLandscapePack = null;
   public static Field memberSoundPack = null;
@@ -125,7 +125,7 @@ public class Reflection {
   public static Method resetTimings = null;
   public static Method formatText = null;
   public static Method putRandom = null;
-  
+
   public static Method loadGameConfig = null;
   public static Method loadEntities = null;
   public static Method loadMaps = null;
@@ -212,7 +212,7 @@ public class Reflection {
   private static final String FORMAT_TEXT =
       "static final java.lang.String b.a(int,byte,java.lang.String)";
   private static final String PUTRANDOM = "static final void f.a(int,tb)";
-  
+
   private static final String LOAD_GAME_CONFIG = "private final void client.f(boolean)";
   private static final String LOAD_ENTITIES = "private final void client.c(boolean)";
   private static final String LOAD_MAPS = "private final void client.m(int)";
@@ -292,17 +292,17 @@ public class Reflection {
           showInputPopup = method;
           Logger.Info("Found showInputPopup");
         } else if (method.toGenericString().equals(LOAD_GAME_CONFIG)) {
-        	loadGameConfig = method;
-        	Logger.Info("Found loadGameConfig");
+          loadGameConfig = method;
+          Logger.Info("Found loadGameConfig");
         } else if (method.toGenericString().equals(LOAD_ENTITIES)) {
-        	loadEntities = method;
-        	Logger.Info("Found loadEntities");
+          loadEntities = method;
+          Logger.Info("Found loadEntities");
         } else if (method.toGenericString().equals(LOAD_MAPS)) {
-        	loadMaps = method;
-        	Logger.Info("Found loadMaps");
+          loadMaps = method;
+          Logger.Info("Found loadMaps");
         } else if (method.toGenericString().equals(LOAD_SOUNDS)) {
-        	loadSounds = method;
-        	Logger.Info("Found loadSounds");
+          loadSounds = method;
+          Logger.Info("Found loadSounds");
         }
       }
 
@@ -707,16 +707,16 @@ public class Reflection {
           Logger.Info("Found gameReference");
         }
       }
-      
+
       c = classLoader.loadClass("k");
       fields = c.getDeclaredFields();
       for (Field field : fields) {
         if (field.getName().equals("m")) {
-        	memberMapPack = field;
+          memberMapPack = field;
           Logger.Info("Found memberMapPack");
         }
         if (field.getName().equals("I")) {
-        	memberLandscapePack = field;
+          memberLandscapePack = field;
           Logger.Info("Found memberLandscapePack");
         }
       }

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -158,6 +158,7 @@ public class Replay {
     paused = false;
     closeDialogue = false;
     replayDirectory = directory;
+    replayMembers = ((int)Replay.readMetadata(directory)[4] & (1 << 31)) == 0; // first bit of user settings is true if replay is F2P
   }
 
   public static int getServerLag() {
@@ -462,8 +463,17 @@ public class Replay {
         for (int i = 0; i < ipAddressMetadata.length; i++) {
           metadata.writeByte(ipAddressMetadata[i]);
         }
-        metadata.writeByte(0); // conversion settings, none used in this case
-        metadata.writeInt(0); // User settings, not implemented for any purpose at this time
+
+        metadata.writeByte(0); // rscminus conversion settings, none used in this case
+
+        int userSettings = 0;
+        // "User settings", 1st bit is used to denote if replay was on F2P or Members world.
+        // Rest of the 31 bits are not implemented for any purpose at this time
+        if (!Client.members) {
+            userSettings |= 1 << 31;
+        }
+        metadata.writeInt(userSettings);
+
         metadata.flush();
         metadata.close();
       } catch (IOException e) {
@@ -798,7 +808,7 @@ public class Replay {
         metadata.writeByte(ipAddressMetadata[i]);
       }
       metadata.writeByte(0); // conversion settings, none used in this case
-      metadata.writeInt(0); // User settings, not implemented for any purpose at this time
+      metadata.writeInt(0); // "User settings", 1st bit is F2P or Members. Since metadata.bin doesn't exist, probably members
       metadata.flush();
       metadata.close();
     } catch (IOException e) {

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -105,6 +105,11 @@ public class Replay {
   public static int prevPlayerX;
   public static int prevPlayerY;
 
+  // TODO: these will be needed to be added as metadata for existing replays
+  // and stored for new ones
+  public static boolean replayMembers = true;
+  public static boolean replayVeterans = false;
+
   public static int timestamp;
   public static int timestamp_disconnect;
   public static int timestamp_client;
@@ -259,6 +264,7 @@ public class Replay {
     replayThread = new Thread(replayServer);
     replayThread.start();
     ignoreFirstMovement = true;
+
     // if (Client.strings[662].startsWith("from:")) {
     // Client.strings[662] = "@bla@from:";
     // }
@@ -271,6 +277,7 @@ public class Replay {
       while (!replayServer.isReady) Thread.sleep(1);
     } catch (Exception e) {
     }
+    Client.switchLiveToReplay(true);
     Client.login(false, "Replay", "");
     updateFrameTimeSlice();
     return true;
@@ -325,7 +332,8 @@ public class Replay {
     isSeeking = false;
     resetFrameTimeSlice();
     Client.closeConnection(false);
-    resetPort();
+    Client.switchLiveToReplay(false);
+    // resetPort();
     // fpsPlayMultiplier = 1.0f;
     resetPatchClient();
     isPlaying = false;

--- a/src/Game/ReplayServer.java
+++ b/src/Game/ReplayServer.java
@@ -242,6 +242,7 @@ public class ReplayServer implements Runnable {
       input.close();
 
       Logger.Debug("ReplayServer: Replay ended");
+      Client.switchLiveToReplay(false);
 
       if (ReplayQueue.currentIndex >= ReplayQueue.queue.size())
         Logger.Info("ReplayServer: Playback has finished");


### PR DESCRIPTION
This PR intends to add this for the client:
* A world may not be members, it may be free. And for any of both types, may be veterans as well. It will display now on change on welcome screen what account type the player needs.
* Allows it to change without reload between free and memb servers (previously would have needed to close down the client and start it again for the changes to take effect), to get applied settings.

~~Has a caveat with soft reload though, with the soft reload if player was in members area then logging to f2p, the region is still displayed and doesn't become water. Conversely if border of cache of f2p then logged to membs the p2p part is not displayed until player is moved to another region then comes back~~