### PR TITLE
Reset Camera Zoom and Rotation Keybinds

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1654,6 +1654,18 @@ public class ConfigWindow {
         "toggle_indicators",
         KeyModifier.CTRL,
         KeyEvent.VK_W);
+    addKeybindSet(
+            keybindContainerPanel,
+            "Reset camera zoom",
+            "reset_zoom",
+            KeyModifier.ALT,
+            KeyEvent.VK_Z);
+    addKeybindSet(
+            keybindContainerPanel,
+            "Reset camera rotation",
+            "reset_rotation",
+            KeyModifier.ALT,
+            KeyEvent.VK_N);
 
     addKeybindCategory(keybindContainerPanel, "Overlays");
     addKeybindSet(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2481,6 +2481,12 @@ public class Settings {
       case "toggle_indicators":
         Settings.toggleLagIndicator();
         return true;
+      case "reset_zoom":
+        Camera.resetZoom();
+        return true;
+      case "reset_rotation":
+        Camera.resetRotation();
+        return true;
       case "toggle_colorize":
         Settings.toggleColorTerminal();
         return true;

--- a/src/Game/Camera.java
+++ b/src/Game/Camera.java
@@ -252,4 +252,14 @@ public class Camera {
       zoom = (int) delta_zoom;
     }
   }
+
+  public static void resetZoom() {
+    zoom = 750;
+    delta_zoom = (float) zoom;
+  }
+
+  public static void resetRotation() {
+    rotation = 126;
+    delta_rotation = (float) rotation;
+  }
 }


### PR DESCRIPTION
Added keybinds for resetting the camera zoom and rotation.
Zoom reset defaults to Alt-Z (for zoom)
Rotation reset defaults to Alt-N (for North)