### PR TITLE
Warning system for if one of your highlighted items has been on the ground too long

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1390,6 +1390,14 @@ public class ConfigWindow {
     notificationPanelHighlightedItemTimerCheckbox.setToolTipText(
         "Highlighted items can be configured in the Overlays tab");
 
+    JLabel highlightedItemsSuggestionJLabel =
+      new JLabel(
+        "<html><p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+          + "<strong>Note:</strong> Loot from kills despawns after about 2 minutes."
+          + "</p></html>");
+    notificationPanel.add(highlightedItemsSuggestionJLabel);
+    highlightedItemsSuggestionJLabel.setBorder(new EmptyBorder(0, 0, 8, 0));
+
     notificationPanelHighlightedItemTimerSpinner = new JSpinner();
     notificationPanelHighlightedItemTimerSpinner.setMaximumSize(new Dimension(55, 22));
     notificationPanelHighlightedItemTimerSpinner.setMinimumSize(new Dimension(55, 22));

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -121,11 +121,6 @@ public class ConfigWindow {
 
   private JFrame frame;
 
-  private JLabel generalPanelNamePatchModeDesc;
-  private JLabel generalPanelCommandPatchModeDesc;
-  private JLabel notificationPanelLowHPNotifsEndLabel;
-  private JLabel notificationPanelFatigueNotifsEndLabel;
-
   ClickListener clickListener = new ClickListener();
   RebindListener rebindListener = new RebindListener();
 
@@ -176,6 +171,7 @@ public class ConfigWindow {
   private JCheckBox generalPanelPatchGenderCheckbox;
   private JCheckBox generalPanelDebugModeCheckbox;
   private JCheckBox generalPanelExceptionHandlerCheckbox;
+  private JLabel generalPanelNamePatchModeDesc;
 
   //// Overlays tab
   private JCheckBox overlayPanelStatusDisplayCheckbox;
@@ -227,6 +223,8 @@ public class ConfigWindow {
   private JSpinner notificationPanelLowHPNotifsSpinner;
   private JCheckBox notificationPanelFatigueNotifsCheckbox;
   private JSpinner notificationPanelFatigueNotifsSpinner;
+  private JCheckBox notificationPanelHighlightedItemTimerCheckbox;
+  private JSpinner notificationPanelHighlightedItemTimerSpinner;
   private JCheckBox notificationPanelNotifSoundsCheckbox;
   private JCheckBox notificationPanelUseSystemNotifsCheckbox;
   private JCheckBox notificationPanelTrayPopupCheckbox;
@@ -1335,7 +1333,7 @@ public class ConfigWindow {
     notificationPanelLowHPNotifsPanel.add(notificationPanelLowHPNotifsSpinner);
     notificationPanelLowHPNotifsSpinner.putClientProperty("JComponent.sizeVariant", "mini");
 
-    notificationPanelLowHPNotifsEndLabel = new JLabel("% HP");
+    JLabel notificationPanelLowHPNotifsEndLabel = new JLabel("% HP");
     notificationPanelLowHPNotifsPanel.add(notificationPanelLowHPNotifsEndLabel);
     notificationPanelLowHPNotifsEndLabel.setAlignmentY((float) 0.9);
     notificationPanelLowHPNotifsEndLabel.setBorder(new EmptyBorder(0, 2, 0, 0));
@@ -1366,7 +1364,7 @@ public class ConfigWindow {
     notificationPanelFatigueNotifsPanel.add(notificationPanelFatigueNotifsSpinner);
     notificationPanelFatigueNotifsSpinner.putClientProperty("JComponent.sizeVariant", "mini");
 
-    notificationPanelFatigueNotifsEndLabel = new JLabel("% fatigue");
+    JLabel notificationPanelFatigueNotifsEndLabel = new JLabel("% fatigue");
     notificationPanelFatigueNotifsPanel.add(notificationPanelFatigueNotifsEndLabel);
     notificationPanelFatigueNotifsEndLabel.setAlignmentY((float) 0.9);
     notificationPanelFatigueNotifsEndLabel.setBorder(new EmptyBorder(0, 2, 0, 0));
@@ -1377,6 +1375,40 @@ public class ConfigWindow {
     spinnerFatigueNumModel.setMaximum(100);
     spinnerFatigueNumModel.setValue(98);
     notificationPanelFatigueNotifsSpinner.setModel(spinnerFatigueNumModel);
+
+    JPanel warnHighlightedOnGroundPanel = new JPanel();
+    notificationPanel.add(warnHighlightedOnGroundPanel);
+    warnHighlightedOnGroundPanel.setLayout(
+        new BoxLayout(warnHighlightedOnGroundPanel, BoxLayout.X_AXIS));
+    warnHighlightedOnGroundPanel.setPreferredSize(new Dimension(0, 37));
+    warnHighlightedOnGroundPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+    notificationPanelHighlightedItemTimerCheckbox =
+        addCheckbox(
+            "Warn if one of your highlighted items has been on the ground for more than",
+            warnHighlightedOnGroundPanel);
+    notificationPanelHighlightedItemTimerCheckbox.setToolTipText(
+        "Highlighted items can be configured in the Overlays tab");
+
+    notificationPanelHighlightedItemTimerSpinner = new JSpinner();
+    notificationPanelHighlightedItemTimerSpinner.setMaximumSize(new Dimension(55, 22));
+    notificationPanelHighlightedItemTimerSpinner.setMinimumSize(new Dimension(55, 22));
+    notificationPanelHighlightedItemTimerSpinner.setAlignmentY((float) 0.75);
+    warnHighlightedOnGroundPanel.add(notificationPanelHighlightedItemTimerSpinner);
+    notificationPanelHighlightedItemTimerSpinner.putClientProperty(
+        "JComponent.sizeVariant", "mini");
+
+    JLabel notificationPanelHighlightedItemEndLabel = new JLabel("seconds");
+    warnHighlightedOnGroundPanel.add(notificationPanelHighlightedItemEndLabel);
+    notificationPanelHighlightedItemEndLabel.setAlignmentY((float) 0.9);
+    notificationPanelHighlightedItemEndLabel.setBorder(new EmptyBorder(0, 2, 0, 0));
+
+    // Sanitize JSpinner values
+    SpinnerNumberModel highlightedItemSecondsModel = new SpinnerNumberModel();
+    highlightedItemSecondsModel.setMinimum(0);
+    highlightedItemSecondsModel.setMaximum(630); // 10.5 minutes max
+    highlightedItemSecondsModel.setValue(100);
+    notificationPanelHighlightedItemTimerSpinner.setModel(highlightedItemSecondsModel);
 
     /*
      * Streaming & Privacy tab
@@ -1613,17 +1645,13 @@ public class ConfigWindow {
         KeyModifier.CTRL,
         KeyEvent.VK_W);
     addKeybindSet(
-            keybindContainerPanel,
-            "Reset camera zoom",
-            "reset_zoom",
-            KeyModifier.ALT,
-            KeyEvent.VK_Z);
+        keybindContainerPanel, "Reset camera zoom", "reset_zoom", KeyModifier.ALT, KeyEvent.VK_Z);
     addKeybindSet(
-            keybindContainerPanel,
-            "Reset camera rotation",
-            "reset_rotation",
-            KeyModifier.ALT,
-            KeyEvent.VK_N);
+        keybindContainerPanel,
+        "Reset camera rotation",
+        "reset_rotation",
+        KeyModifier.ALT,
+        KeyEvent.VK_N);
 
     addKeybindCategory(keybindContainerPanel, "Overlays");
     addKeybindSet(
@@ -2527,6 +2555,10 @@ public class ConfigWindow {
         Settings.FATIGUE_NOTIFICATIONS.get(Settings.currentProfile));
     notificationPanelFatigueNotifsSpinner.setValue(
         Settings.FATIGUE_NOTIF_VALUE.get(Settings.currentProfile));
+    notificationPanelHighlightedItemTimerCheckbox.setSelected(
+        Settings.HIGHLIGHTED_ITEM_NOTIFICATIONS.get(Settings.currentProfile));
+    notificationPanelHighlightedItemTimerSpinner.setValue(
+        Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile));
     notificationPanelNotifSoundsCheckbox.setSelected(
         Settings.NOTIFICATION_SOUNDS.get(Settings.currentProfile));
     notificationPanelUseSystemNotifsCheckbox.setSelected(
@@ -2762,6 +2794,13 @@ public class ConfigWindow {
     Settings.FATIGUE_NOTIF_VALUE.put(
         Settings.currentProfile,
         ((SpinnerNumberModel) (notificationPanelFatigueNotifsSpinner.getModel()))
+            .getNumber()
+            .intValue());
+    Settings.HIGHLIGHTED_ITEM_NOTIFICATIONS.put(
+        Settings.currentProfile, notificationPanelHighlightedItemTimerCheckbox.isSelected());
+    Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.put(
+        Settings.currentProfile,
+        ((SpinnerNumberModel) (notificationPanelHighlightedItemTimerSpinner.getModel()))
             .getNumber()
             .intValue());
     Settings.NOTIFICATION_SOUNDS.put(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -859,6 +859,18 @@ public class JClassPatcher {
           "Game/JGameData",
           "objectNames",
           "[Ljava/lang/String;");
+
+      // current ground items
+      hookClassVariable(
+          methodNode, "client", "Zf", "[I", "Game/Item", "groundItemX", "[I", true, false);
+      hookClassVariable(
+          methodNode, "client", "Ni", "[I", "Game/Item", "groundItemY", "[I", true, false);
+      hookClassVariable(
+          methodNode, "client", "Le", "[I", "Game/Item", "groundItemZ", "[I", true, false);
+      hookClassVariable(
+          methodNode, "client", "Gj", "[I", "Game/Item", "groundItemId", "[I", true, false);
+      hookClassVariable(
+          methodNode, "client", "Ah", "I", "Game/Item", "groundItemCount", "I", true, false);
     }
   }
 

--- a/src/Client/NotificationsHandler.java
+++ b/src/Client/NotificationsHandler.java
@@ -74,7 +74,8 @@ public class NotificationsHandler {
     DUEL,
     LOGOUT,
     LOWHP,
-    FATIGUE
+    FATIGUE,
+    HIGHLIGHTEDITEM
   }
 
   /** Initializes the Notification JFrame and prepares it to receive notifications */
@@ -487,6 +488,20 @@ public class NotificationsHandler {
           }
           break;
         }
+      case HIGHLIGHTEDITEM:
+        if (Settings.HIGHLIGHTED_ITEM_NOTIFICATIONS.get(Settings.currentProfile)) {
+          if (Settings.NOTIFICATION_SOUNDS.get(Settings.currentProfile)) {
+            // If notification sounds, play audio
+            playNotificationSound();
+            didNotify = true;
+          }
+          if (Settings.TRAY_NOTIFS.get(Settings.currentProfile)) {
+            // This is very important, we will always warn, even if game is focused
+            displayNotification(title, text, "critical");
+            didNotify = true;
+          }
+        }
+        break;
     }
     return didNotify;
   }

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -173,6 +173,10 @@ public class Settings {
   public static HashMap<String, Integer> LOW_HP_NOTIF_VALUE = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> FATIGUE_NOTIFICATIONS = new HashMap<String, Boolean>();
   public static HashMap<String, Integer> FATIGUE_NOTIF_VALUE = new HashMap<String, Integer>();
+  public static HashMap<String, Boolean> HIGHLIGHTED_ITEM_NOTIFICATIONS =
+      new HashMap<String, Boolean>();
+  public static HashMap<String, Integer> HIGHLIGHTED_ITEM_NOTIF_VALUE =
+      new HashMap<String, Integer>();
 
   //// streaming
   public static HashMap<String, Boolean> TWITCH_CHAT_ENABLED = new HashMap<String, Boolean>();
@@ -1101,6 +1105,30 @@ public class Settings {
     FATIGUE_NOTIF_VALUE.put(
         "custom", getPropInt(props, "fatigue_notif_value", FATIGUE_NOTIF_VALUE.get("default")));
 
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("vanilla", false);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("vanilla_resizable", false);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("lite", false);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("default", true);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("heavy", true);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put("all", true);
+    HIGHLIGHTED_ITEM_NOTIFICATIONS.put(
+        "custom",
+        getPropBoolean(
+            props,
+            "highlighted_item_notifications",
+            HIGHLIGHTED_ITEM_NOTIFICATIONS.get("default")));
+
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("vanilla", 11000);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("vanilla_resizable", 11000);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("lite", 100);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("default", 100);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("heavy", 100);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put("all", 0);
+    HIGHLIGHTED_ITEM_NOTIF_VALUE.put(
+        "custom",
+        getPropInt(
+            props, "highlighted_item_notif_value", HIGHLIGHTED_ITEM_NOTIF_VALUE.get("default")));
+
     //// streaming
     TWITCH_CHAT_ENABLED.put("vanilla", false);
     TWITCH_CHAT_ENABLED.put("vanilla_resizable", false);
@@ -1871,6 +1899,12 @@ public class Settings {
       props.setProperty(
           "fatigue_notifications", Boolean.toString(FATIGUE_NOTIFICATIONS.get(preset)));
       props.setProperty("fatigue_notif_value", Integer.toString(FATIGUE_NOTIF_VALUE.get(preset)));
+      props.setProperty(
+          "highlighted_item_notifications",
+          Boolean.toString(HIGHLIGHTED_ITEM_NOTIFICATIONS.get(preset)));
+      props.setProperty(
+          "highlighted_item_notif_value",
+          Integer.toString(HIGHLIGHTED_ITEM_NOTIF_VALUE.get(preset)));
 
       //// streaming
       props.setProperty("twitch_enabled", Boolean.toString(TWITCH_CHAT_ENABLED.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -280,6 +280,8 @@ public class Client {
   public static String lastServerMessage = "";
   public static int[] inputFilterCharFontAddr;
 
+  public static byte[] lastIncomingBytes;
+
   public static Thread loginMessageHandlerThread;
   public static String loginMessageTop =
       "To connect to a server, please configure your World URLs.";

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -231,15 +231,15 @@ public class Item {
   public static void checkForNewItems(int psize) {
     int offset = 1;
     while (offset < psize) {
-      int remove = Replay.retained_bytes[offset++] & 0xFF;
+      int remove = Client.lastIncomingBytes[offset++] & 0xFF;
       if (remove == 255) {
-        int x = Client.worldX + (Replay.retained_bytes[offset++] & 0xFF);
-        int y = Client.worldY + (Replay.retained_bytes[offset++] & 0xFF);
+        int x = Client.worldX + (Client.lastIncomingBytes[offset++] & 0xFF);
+        int y = Client.worldY + (Client.lastIncomingBytes[offset++] & 0xFF);
         removeFromCoolItems(x, y, -1);
       } else {
-        int itemId = remove << 8 | Replay.retained_bytes[offset++] & 0xFF;
-        int x = Client.worldX + (Replay.retained_bytes[offset++] & 0xFF);
-        int y = Client.worldY + (Replay.retained_bytes[offset++] & 0xFF);
+        int itemId = remove << 8 | Client.lastIncomingBytes[offset++] & 0xFF;
+        int x = Client.worldX + (Client.lastIncomingBytes[offset++] & 0xFF);
+        int y = Client.worldY + (Client.lastIncomingBytes[offset++] & 0xFF);
         // first bit on means removing a specific item, don't care in that case
         boolean addingAnItem = (remove & 0x80) >> 7 != 1;
         if (addingAnItem) {

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -19,6 +19,7 @@
 package Game;
 
 import Client.Logger;
+import Client.NotificationsHandler;
 import Client.Settings;
 import java.io.File;
 import java.sql.Connection;
@@ -27,6 +28,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * This class defines items and provides a static method to patch item names as needed according to
@@ -36,12 +40,20 @@ public class Item {
 
   public static String[] item_name;
   public static String[] item_commands;
+  public static List<Item> cool_items = new ArrayList<>();
+
+  public static int[] groundItemX;
+  public static int[] groundItemY;
+  public static int[] groundItemZ;
+  public static int[] groundItemId;
+  public static int groundItemCount;
 
   public int x;
   public int y;
   public int width;
   public int height;
   public int id;
+  public long timestamp;
 
   public Item(int x, int y, int width, int height, int id) {
     this.x = x;
@@ -49,6 +61,13 @@ public class Item {
     this.width = width;
     this.height = height;
     this.id = id;
+  }
+
+  public Item(int x, int y, int id, long timestamp) {
+    this.x = x;
+    this.y = y;
+    this.id = id;
+    this.timestamp = timestamp;
   }
 
   /** Patches item names as specified by {@link Settings#NAME_PATCH_TYPE}. */
@@ -207,5 +226,78 @@ public class Item {
     // This is an acceptable hash since it's fine if two unequal objects have the same hash
     // according to docs
     return this.x + this.y + this.width + this.height + this.id;
+  }
+
+  public static void checkForNewItems(int psize) {
+    int offset = 1;
+    while (offset < psize) {
+      int remove = Replay.retained_bytes[offset++] & 0xFF;
+      if (remove == 255) {
+        int x = Client.worldX + (Replay.retained_bytes[offset++] & 0xFF);
+        int y = Client.worldY + (Replay.retained_bytes[offset++] & 0xFF);
+        removeFromCoolItems(x, y, -1);
+      } else {
+        int itemId = remove << 8 | Replay.retained_bytes[offset++] & 0xFF;
+        int x = Client.worldX + (Replay.retained_bytes[offset++] & 0xFF);
+        int y = Client.worldY + (Replay.retained_bytes[offset++] & 0xFF);
+        // first bit on means removing a specific item, don't care in that case
+        boolean addingAnItem = (remove & 0x80) >> 7 != 1;
+        if (addingAnItem) {
+          if (Renderer.stringIsWithinList(
+              item_name[itemId], Settings.HIGHLIGHTED_ITEMS.get("custom"))) {
+            cool_items.add(new Item(x, y, itemId, System.currentTimeMillis()));
+          }
+        } else {
+          // TODO: this removes the oldest item, but not sure that's correct.
+          removeFromCoolItems(x, y, itemId & 0x7F);
+        }
+      }
+    }
+  }
+
+  private static void removeFromCoolItems(int x, int y, int itemId) {
+    Iterator<Item> iterator = cool_items.iterator();
+    Item coolItem;
+    while (iterator.hasNext()) {
+      coolItem = iterator.next();
+      if (coolItem.x == x && coolItem.y == y) {
+        if (itemId == -1 || itemId == coolItem.id) {
+          iterator.remove();
+          if (itemId != -1) {
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  public static void checkForImminentlyDespawningCoolItem() {
+    Iterator<Item> iterator = cool_items.iterator();
+    Item coolItem;
+    while (iterator.hasNext()) {
+      coolItem = iterator.next();
+      boolean itemGoingStale =
+          System.currentTimeMillis() - coolItem.timestamp
+              > 1000 * Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile);
+      if (itemGoingStale) {
+        // check if item still exists
+        for (int i = 0; i < groundItemCount; i++) {
+          int x = groundItemX[i] + Client.regionX;
+          int y = groundItemY[i] + Client.regionY;
+          if (x == coolItem.x && y == coolItem.y && groundItemId[i] == coolItem.id) {
+            // "an" item with same item id & x & y coordinate still exists on the ground
+            Logger.Info("@|red,bold Make sure to pick up your " + item_name[coolItem.id] + "!|@");
+            NotificationsHandler.notify(
+                NotificationsHandler.NotifType.HIGHLIGHTEDITEM,
+                "Highlighted Item Notification",
+                item_name[coolItem.id]
+                    + " has been on the ground for "
+                    + Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile)
+                    + " seconds!");
+            iterator.remove();
+          }
+        }
+      }
+    }
   }
 }

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -286,14 +286,23 @@ public class Item {
           int y = groundItemY[i] + Client.regionY;
           if (x == coolItem.x && y == coolItem.y && groundItemId[i] == coolItem.id) {
             // "an" item with same item id & x & y coordinate still exists on the ground
-            Logger.Info("@|red,bold Make sure to pick up your " + item_name[coolItem.id] + "!|@");
-            NotificationsHandler.notify(
+            Client.displayMessage("@lre@[@gre@RSC+@lre@]: @red@Make sure to pick up your " + item_name[coolItem.id] + "!", Client.CHAT_NONE);
+            if (Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile) > 0) {
+              NotificationsHandler.notify(
                 NotificationsHandler.NotifType.HIGHLIGHTEDITEM,
                 "Highlighted Item Notification",
                 item_name[coolItem.id]
-                    + " has been on the ground for "
-                    + Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile)
-                    + " seconds!");
+                  + " has been on the ground for "
+                  + Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile)
+                  + " second"
+                  + (Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile) == 1 ? "!" : "s!"));
+            } else {
+              NotificationsHandler.notify(
+                NotificationsHandler.NotifType.HIGHLIGHTEDITEM,
+                "Highlighted Item Notification",
+                item_name[coolItem.id]
+                  + " appeared!");
+            }
             iterator.remove();
           }
         }

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -249,7 +249,7 @@ public class Item {
           }
         } else {
           // TODO: this removes the oldest item, but not sure that's correct.
-          removeFromCoolItems(x, y, itemId & 0x7F);
+          removeFromCoolItems(x, y, itemId & 0x7FFF);
         }
       }
     }

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1092,6 +1092,8 @@ public class Replay {
   }
 
   public static void dumpRawInputStream(byte[] b, int n, int n2, int n5, int bytesread) {
+    Client.lastIncomingBytes = b.clone();
+
     // Save timestamp of last time we saw data from the server
     if (bytesread > 0) {
       int lag = timestamp - timestamp_server_last;

--- a/src/Game/Replay.java
+++ b/src/Game/Replay.java
@@ -1289,6 +1289,10 @@ public class Replay {
         // free memory
         retained_bytes = null;
       }
+    } else if (opcode == 99) {
+      Item.checkForNewItems(len);
+    } else if (opcode == 191) {
+      Item.checkForImminentlyDespawningCoolItem();
     }
 
     if (!isPlaying && !isSeeking) {


### PR DESCRIPTION
Highlighted items are an existing concept in RSC+; they can be configured from the Overlays tab of settings. Items are highlighted because the user has told RSC+ that those items are interesting to them. This PR introduces the ability to trigger a notification when an item interesting enough to be highlighted has been on the ground for longer than the user is comfortable with. By default, this value is 100 seconds, because I think authentic item despawn timer is 2 minutes. Not completely sure on that, but it seems like a good default. The maximum is 10.5 minutes, because items dropped on death survive for about 10 minutes authentically.

Here is what the system looks like: 

![pickup your darts](https://user-images.githubusercontent.com/1337967/113108265-6b9ffb00-91ca-11eb-95b0-e12b89a3ee94.png)

Notifications will always fire  regardless of focus (if this Highlighted Items notification type is enabled under Notifications tab), because it is extremely important to receive the message that an item important to them may soon leave this world.
