### PR TITLE
Re-click map and settings icons to close

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -363,7 +363,7 @@ public class ConfigWindow {
 
   public void showConfigWindow() {
     this.synchronizeGuiValues();
-    frame.setVisible(true);
+    frame.setVisible(!isShown());
   }
 
   public void hideConfigWindow() {

--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -1430,8 +1430,10 @@ public class WorldMapWindow {
     if (!frame.isVisible()) {
       searchText = "";
       updateMapRender();
+      frame.setVisible(true);
+    } else {
+      frame.setVisible(false);
     }
-    frame.setVisible(true);
   }
 
   private static void setZoom(float val) {


### PR DESCRIPTION
Often find myself clicking the map icon just to double check something real quick around me and thought it would be nice to be able to close it by clicking the same button again.

I tested this out and it seems to work but I haven't really spent any time with the code base, so apologies if I missed something else that needs to be changed as a result of this.