### PR TITLE
Re-click map and settings icons to close

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -362,11 +362,15 @@ public class ConfigWindow {
   }
 
   public void showConfigWindow() {
+    Client.displayMessage("Showing config window...", Client.CHAT_NONE);
+
     this.synchronizeGuiValues();
     frame.setVisible(true);
   }
 
   public void hideConfigWindow() {
+    Client.displayMessage("Hid the config window.", Client.CHAT_NONE);
+
     frame.setVisible(false);
   }
 

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -363,7 +363,7 @@ public class ConfigWindow {
 
   public void showConfigWindow() {
     this.synchronizeGuiValues();
-    frame.setVisible(true);
+    frame.setVisible(!isShown());
   }
 
   public void hideConfigWindow() {

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -367,7 +367,6 @@ public class ConfigWindow {
   }
 
   public void hideConfigWindow() {
-    this.synchronizeGuiValues();
     frame.setVisible(false);
   }
 

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -363,11 +363,20 @@ public class ConfigWindow {
 
   public void showConfigWindow() {
     this.synchronizeGuiValues();
-    frame.setVisible(!isShown());
+    frame.setVisible(true);
   }
 
   public void hideConfigWindow() {
+    this.synchronizeGuiValues();
     frame.setVisible(false);
+  }
+
+  public void toggleConfigWindow() {
+    if (this.isShown()) {
+      this.hideConfigWindow();
+    } else {
+      this.showConfigWindow();
+    }
   }
 
   public boolean isShown() {

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -3521,10 +3521,10 @@ public class Settings {
         Settings.toggleStartSearchedBank("", false);
         return true;
       case "show_config_window":
-        Launcher.getConfigWindow().showConfigWindow();
+        Launcher.getConfigWindow().toggleConfigWindow();
         return true;
       case "show_worldmap_window":
-        Launcher.getWorldMapWindow().showWorldMapWindow();
+        Launcher.getWorldMapWindow().toggleWorldMapWindow();
         return true;
       case "show_queue_window":
         // Try to not allow Replay window to appear while logged into the game :-)

--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -1430,8 +1430,10 @@ public class WorldMapWindow {
     if (!frame.isVisible()) {
       searchText = "";
       updateMapRender();
+      frame.setVisible(true);
+    } else {
+      frame.setVisible(false);
     }
-    frame.setVisible(true);
   }
 
   private static void setZoom(float val) {

--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -1427,6 +1427,8 @@ public class WorldMapWindow {
   }
 
   public void showWorldMapWindow() {
+    Client.displayMessage("Showing world map window...", Client.CHAT_NONE);
+
     if (!isShown()) {
       searchText = "";
       updateMapRender();
@@ -1436,6 +1438,8 @@ public class WorldMapWindow {
   }
 
   public void hideWorldMapWindow() {
+    Client.displayMessage("Hid the world map window.", Client.CHAT_NONE);
+
     frame.setVisible(false);
   }
 

--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -1427,13 +1427,28 @@ public class WorldMapWindow {
   }
 
   public void showWorldMapWindow() {
-    if (!frame.isVisible()) {
+    if (!isShown()) {
       searchText = "";
       updateMapRender();
-      frame.setVisible(true);
-    } else {
-      frame.setVisible(false);
     }
+
+    frame.setVisible(true);
+  }
+
+  public void hideWorldMapWindow() {
+    frame.setVisible(false);
+  }
+
+  public void toggleWorldMapWindow() {
+    if (isShown()) {
+      this.hideWorldMapWindow();
+    } else {
+      this.showWorldMapWindow();
+    }
+  }
+
+  public static boolean isShown() {
+    return frame.isVisible();
   }
 
   private static void setZoom(float val) {
@@ -1558,7 +1573,7 @@ public class WorldMapWindow {
       cameraCurrentPosition.y = ((y - planeIndex) * 3) + 1;
     }
 
-    if (!frame.isVisible()) return;
+    if (!isShown()) return;
 
     // Repaint if data changed
     if (dirty

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -888,7 +888,7 @@ public class Renderer {
               && MouseHandler.y <= mapButtonBounds.y + mapButtonBounds.height
               && MouseHandler.mouseClicked) {
 
-            Launcher.getWorldMapWindow().showWorldMapWindow();
+            Launcher.getWorldMapWindow().toggleWorldMapWindow();
           }
         }
 
@@ -915,7 +915,7 @@ public class Renderer {
               && MouseHandler.y >= mapButtonBounds.y
               && MouseHandler.y <= mapButtonBounds.y + mapButtonBounds.height
               && MouseHandler.mouseClicked) {
-            Launcher.getConfigWindow().showConfigWindow();
+            Launcher.getConfigWindow().toggleConfigWindow();
           }
         }
 


### PR DESCRIPTION
Often find myself clicking the map icon just to double check something real quick around me and thought it would be nice to be able to close it by clicking the same button again.

I tested this out and it seems to work but I haven't really spent any time with the code base, so apologies if I missed something else that needs to be changed as a result of this.

Also applied the same idea to the settings icon.