### PR TITLE
denylist for pm notifications

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -287,6 +287,7 @@ public class ConfigWindow {
 
   //// Notifications tab
   private JCheckBox notificationPanelPMNotifsCheckbox;
+  private JTextField notificationPanelPMDenyListTextField;
   private JCheckBox notificationPanelTradeNotifsCheckbox;
   private JCheckBox notificationPanelDuelNotifsCheckbox;
   private JCheckBox notificationPanelLogoutNotifsCheckbox;
@@ -1893,6 +1894,24 @@ public class ConfigWindow {
     notificationPanelPMNotifsCheckbox.setToolTipText(
         "Shows a system notification when a PM is received");
 
+    // PM notifications denylist
+    JPanel pmDenylistPanel = new JPanel();
+    notificationPanel.add(pmDenylistPanel);
+    pmDenylistPanel.setLayout(new BoxLayout(pmDenylistPanel, BoxLayout.X_AXIS));
+    pmDenylistPanel.setPreferredSize(new Dimension(0, 37));
+    pmDenylistPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    pmDenylistPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
+
+    JLabel pmDenyListNameLabel = new JLabel("Disable PM notifications from: ");
+    pmDenylistPanel.add(pmDenyListNameLabel);
+    pmDenyListNameLabel.setAlignmentY((float) 0.9);
+
+    notificationPanelPMDenyListTextField = new JTextField();
+    pmDenylistPanel.add(notificationPanelPMDenyListTextField);
+    notificationPanelPMDenyListTextField.setMinimumSize(new Dimension(100, 28));
+    notificationPanelPMDenyListTextField.setMaximumSize(new Dimension(Short.MAX_VALUE, 28));
+    notificationPanelPMDenyListTextField.setAlignmentY((float) 0.75);
+
     notificationPanelTradeNotifsCheckbox =
         addCheckbox("Enable trade notifications", notificationPanel);
     notificationPanelTradeNotifsCheckbox.setToolTipText(
@@ -3469,6 +3488,8 @@ public class ConfigWindow {
     // Notifications tab
     notificationPanelPMNotifsCheckbox.setSelected(
         Settings.PM_NOTIFICATIONS.get(Settings.currentProfile));
+    notificationPanelPMDenyListTextField.setText(
+        Util.joinAsString(",", Settings.PM_DENYLIST.get("custom")));
     notificationPanelTradeNotifsCheckbox.setSelected(
         Settings.TRADE_NOTIFICATIONS.get(Settings.currentProfile));
     notificationPanelDuelNotifsCheckbox.setSelected(
@@ -3826,6 +3847,8 @@ public class ConfigWindow {
     // Notifications options
     Settings.PM_NOTIFICATIONS.put(
         Settings.currentProfile, notificationPanelPMNotifsCheckbox.isSelected());
+    Settings.PM_DENYLIST.put(
+        "custom", new ArrayList<>(Arrays.asList(notificationPanelPMDenyListTextField.getText().split(","))));
     Settings.TRADE_NOTIFICATIONS.put(
         Settings.currentProfile, notificationPanelTradeNotifsCheckbox.isSelected());
     Settings.DUEL_NOTIFICATIONS.put(

--- a/src/Client/NotificationsHandler.java
+++ b/src/Client/NotificationsHandler.java
@@ -18,6 +18,8 @@
  */
 package Client;
 
+import static Game.Renderer.exactStringIgnoreCaseIsWithinList;
+
 import Game.Client;
 import Game.Game;
 import Game.Replay;
@@ -346,14 +348,15 @@ public class NotificationsHandler {
    * @param type The NotifType to display. This can be one of SYSTEM, PM, TRADE, DUEL LOGOUT, LOWHP,
    *     or FATIGUE as of the writing of this documentation.
    * @param title The title to use for the notification.
+   * @param username The username to use for the notification, if available.
    * @param text Text message of the notification.
    * @return True if at least one type of notification (audio/popup) was attempted; false otherwise
    */
-  public static boolean notify(NotifType type, String title, String text) {
-    return notify(type, title, text, "default");
+  public static boolean notify(NotifType type, String title, String username, String text) {
+    return notify(type, title, username, text, "default");
   }
 
-  public static boolean notify(NotifType type, String title, String text, String sound) {
+  public static boolean notify(NotifType type, String title, String username, String text, String sound) {
     boolean didNotify = false;
 
     if (Replay.isPlaying && !Settings.TRIGGER_ALERTS_REPLAY.get(Settings.currentProfile)) {
@@ -363,7 +366,8 @@ public class NotificationsHandler {
     switch (type) {
       case PM:
         {
-          if (Settings.PM_NOTIFICATIONS.get(Settings.currentProfile)) {
+          if (Settings.PM_NOTIFICATIONS.get(Settings.currentProfile) &&
+              !exactStringIgnoreCaseIsWithinList(username, Settings.PM_DENYLIST.get("custom"))) {
             if (Settings.NOTIFICATION_SOUNDS.get(Settings.currentProfile)) {
               // If always notification sounds or if game isn't focused, play audio
               if (Settings.SOUND_NOTIFS_ALWAYS.get(Settings.currentProfile)

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -239,6 +239,8 @@ public class Settings {
   public static HashMap<String, Boolean> SOUND_NOTIFS_ALWAYS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> USE_SYSTEM_NOTIFICATIONS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> PM_NOTIFICATIONS = new HashMap<String, Boolean>();
+  public static HashMap<String, ArrayList<String>> PM_DENYLIST =
+      new HashMap<String, ArrayList<String>>();
   public static HashMap<String, Boolean> TRADE_NOTIFICATIONS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> DUEL_NOTIFICATIONS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> LOGOUT_NOTIFICATIONS = new HashMap<String, Boolean>();
@@ -1743,6 +1745,16 @@ public class Settings {
     PM_NOTIFICATIONS.put(
         "custom", getPropBoolean(props, "pm_notifications", PM_NOTIFICATIONS.get("default")));
 
+    PM_DENYLIST.put("vanilla", new ArrayList<String>());
+    PM_DENYLIST.put("vanilla_resizable", new ArrayList<String>());
+    PM_DENYLIST.put("lite", new ArrayList<String>());
+    PM_DENYLIST.put("default", new ArrayList<String>());
+    PM_DENYLIST.put("heavy", new ArrayList<String>());
+    PM_DENYLIST.put("all", new ArrayList<String>());
+    PM_DENYLIST.put(
+        "custom",
+        getPropArrayListString(props, "pm_denylist", PM_DENYLIST.get("default")));
+
     TRADE_NOTIFICATIONS.put("vanilla", false);
     TRADE_NOTIFICATIONS.put("vanilla_resizable", false);
     TRADE_NOTIFICATIONS.put("lite", false);
@@ -2762,6 +2774,8 @@ public class Settings {
       props.setProperty(
           "use_system_notifications", Boolean.toString(USE_SYSTEM_NOTIFICATIONS.get(preset)));
       props.setProperty("pm_notifications", Boolean.toString(PM_NOTIFICATIONS.get(preset)));
+      props.setProperty(
+          "pm_denylist", Util.joinAsString(",", PM_DENYLIST.get(preset)));
       props.setProperty("trade_notifications", Boolean.toString(TRADE_NOTIFICATIONS.get(preset)));
       props.setProperty("duel_notifications", Boolean.toString(DUEL_NOTIFICATIONS.get(preset)));
       props.setProperty("logout_notifications", Boolean.toString(LOGOUT_NOTIFICATIONS.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2815,10 +2815,10 @@ public class Client {
 
     // notify if the user set the message as one they wanted to be alerted by
     if (Renderer.stringIsWithinList(message, Settings.IMPORTANT_MESSAGES.get("custom"))) {
-      NotificationsHandler.notify(NotifType.IMPORTANT_MESSAGE, "Important message", message);
+      NotificationsHandler.notify(NotifType.IMPORTANT_MESSAGE, "Important message", username, message);
     }
     if (Renderer.stringIsWithinList(message, Settings.IMPORTANT_SAD_MESSAGES.get("custom"))) {
-      NotificationsHandler.notify(NotifType.IMPORTANT_MESSAGE, "Important message", message, "sad");
+      NotificationsHandler.notify(NotifType.IMPORTANT_MESSAGE, "Important message", username, message, "sad");
     }
 
     if (Settings.takingSceneryScreenshots) {
@@ -2863,7 +2863,7 @@ public class Client {
             && message.contains(
                 "You have been standing here for 5 mins! Please move to a new area")) {
           NotificationsHandler.notify(
-              NotifType.LOGOUT, "Logout Notification", "You're about to log out");
+              NotifType.LOGOUT, "Logout Notification", null, "You're about to log out");
         }
         // while the message is really You @gr2@are @gr1@poisioned! @gr2@You @gr3@lose @gr2@3
         // @gr1@health.
@@ -2881,17 +2881,17 @@ public class Client {
         }
       }
     } else if (type == CHAT_PRIVATE) {
-      NotificationsHandler.notify(NotifType.PM, "PM from " + username, message);
+      NotificationsHandler.notify(NotifType.PM, "PM from " + username, username, message);
     } else if (type == CHAT_TRADE_REQUEST_RECEIVED) {
       // as far as I know, this chat type is only used when receiving a trade request.
       // (message == "") is true for trade notifications... could be used if
       // CHAT_TRADE_REQUEST_RECEIVED is used for anything else
       NotificationsHandler.notify(
-          NotifType.TRADE, "Trade Request", username + " wishes to trade with you");
+          NotifType.TRADE, "Trade Request", username, username + " wishes to trade with you");
     } else if (type == CHAT_OTHER) {
       if (message.contains(" wishes to duel with you"))
         NotificationsHandler.notify(
-            NotifType.DUEL, "Duel Request", message.replaceAll("@...@", ""));
+            NotifType.DUEL, "Duel Request", username, message.replaceAll("@...@", ""));
     }
 
     if (type == Client.CHAT_PRIVATE || type == Client.CHAT_PRIVATE_OUTGOING) {

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -231,6 +231,7 @@ public class Item {
                 NotificationsHandler.notify(
                     NotificationsHandler.NotifType.HIGHLIGHTEDITEM,
                     "Highlighted Item Notification",
+                    null,
                     item_name[coolItem.id]
                         + " has been on the ground for "
                         + Settings.HIGHLIGHTED_ITEM_NOTIF_VALUE.get(Settings.currentProfile)
@@ -242,6 +243,7 @@ public class Item {
                 NotificationsHandler.notify(
                     NotificationsHandler.NotifType.HIGHLIGHTEDITEM,
                     "Highlighted Item Notification",
+                    null,
                     item_name[coolItem.id] + " appeared!");
               }
               iterator.remove();

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -520,7 +520,7 @@ public class Renderer {
           && lastPercentHP > percentHP
           && lastPercentHP > Settings.LOW_HP_NOTIF_VALUE.get(Settings.currentProfile))
         NotificationsHandler.notify(
-            NotifType.LOWHP, "Low HP Notification", "Your HP is at " + percentHP + "%");
+            NotifType.LOWHP, "Low HP Notification", null, "Your HP is at " + percentHP + "%");
       lastPercentHP = percentHP;
 
       // High fatigue notification
@@ -530,6 +530,7 @@ public class Renderer {
         NotificationsHandler.notify(
             NotifType.FATIGUE,
             "High Fatigue Notification",
+            null,
             "Your fatigue is at " + Client.getFatigue() + "%");
       lastFatigue = Client.getFatigue();
 
@@ -2218,6 +2219,21 @@ public class Renderer {
       String item = String.valueOf(it.next());
       if (item.trim().length() > 0
           && input.trim().toLowerCase().contains(item.trim().toLowerCase())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean exactStringIgnoreCaseIsWithinList(String input, ArrayList<String> items) {
+    if (items.size() <= 0) {
+      return false;
+    }
+    Iterator it = items.iterator();
+    while (it.hasNext()) {
+      String item = String.valueOf(it.next());
+      if (item.trim().length() > 0
+          && input.trim().equalsIgnoreCase(item.trim())) {
         return true;
       }
     }


### PR DESCRIPTION
Adding an optional exclusion list for the "enable PM notifications" setting.

Usernames will match exactly, though case-insensitively.