### PR TITLE
Numbered dialogue options

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -175,6 +175,7 @@ public class ConfigWindow {
   private JCheckBox generalPanelCommandPatchEdibleRaresCheckbox;
   private JCheckBox generalPanelCommandPatchDiskOfReturningCheckbox;
   private JCheckBox generalPanelBypassAttackCheckbox;
+  private JCheckBox generalPanelNumberedDialogueOptionsCheckbox;
   private JCheckBox generalPanelEnableMouseWheelScrollingCheckbox;
   private JCheckBox generalPanelKeepScrollbarPosMagicPrayerCheckbox;
   private JCheckBox generalPanelRoofHidingCheckbox;
@@ -1407,6 +1408,10 @@ public class ConfigWindow {
     generalPanelBypassAttackCheckbox.setToolTipText(
         "Left click attack monsters regardless of level difference");
     generalPanelBypassAttackCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
+
+    generalPanelNumberedDialogueOptionsCheckbox = addCheckbox("Display numbers next to dialogue options", generalPanel);
+    generalPanelNumberedDialogueOptionsCheckbox.setToolTipText(
+        "Displays a number next to each option within a conversational menu");
 
     generalPanelCommandPatchEdibleRaresCheckbox =
         addCheckbox("Disable the ability to ingest holiday items or rares", generalPanel);
@@ -2678,6 +2683,12 @@ public class ConfigWindow {
         KeyEvent.VK_O);
     addKeybindSet(
         keybindContainerPanel,
+        "Toggle numbered dialogue",
+        "toggle_numbered_dialogue",
+        KeyModifier.ALT,
+        KeyEvent.VK_B);
+    addKeybindSet(
+        keybindContainerPanel,
         "Show world map window",
         "show_worldmap_window",
         KeyModifier.ALT,
@@ -3720,6 +3731,8 @@ public class ConfigWindow {
         Settings.COMMAND_PATCH_DISK.get(Settings.currentProfile));
     generalPanelBypassAttackCheckbox.setSelected(
         Settings.ATTACK_ALWAYS_LEFT_CLICK.get(Settings.currentProfile));
+    generalPanelNumberedDialogueOptionsCheckbox.setSelected(
+        Settings.NUMBERED_DIALOGUE_OPTIONS.get(Settings.currentProfile));
     generalPanelEnableMouseWheelScrollingCheckbox.setSelected(
         Settings.ENABLE_MOUSEWHEEL_SCROLLING.get(Settings.currentProfile));
     generalPanelKeepScrollbarPosMagicPrayerCheckbox.setSelected(
@@ -4208,6 +4221,8 @@ public class ConfigWindow {
         Settings.currentProfile, generalPanelCommandPatchQuestCheckbox.isSelected());
     Settings.ATTACK_ALWAYS_LEFT_CLICK.put(
         Settings.currentProfile, generalPanelBypassAttackCheckbox.isSelected());
+    Settings.NUMBERED_DIALOGUE_OPTIONS.put(
+        Settings.currentProfile, generalPanelNumberedDialogueOptionsCheckbox.isSelected());
     Settings.ENABLE_MOUSEWHEEL_SCROLLING.put(
         Settings.currentProfile, generalPanelEnableMouseWheelScrollingCheckbox.isSelected());
     Settings.KEEP_SCROLLBAR_POS_MAGIC_PRAYER.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -106,6 +106,7 @@ public class Settings {
       new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMMAND_PATCH_DISK = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> ATTACK_ALWAYS_LEFT_CLICK = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> NUMBERED_DIALOGUE_OPTIONS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> ENABLE_MOUSEWHEEL_SCROLLING =
       new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> KEEP_SCROLLBAR_POS_MAGIC_PRAYER =
@@ -665,6 +666,15 @@ public class Settings {
     ATTACK_ALWAYS_LEFT_CLICK.put("all", true);
     ATTACK_ALWAYS_LEFT_CLICK.put(
         "custom", getPropBoolean(props, "bypass_attack", ATTACK_ALWAYS_LEFT_CLICK.get("default")));
+
+    NUMBERED_DIALOGUE_OPTIONS.put("vanilla", false);
+    NUMBERED_DIALOGUE_OPTIONS.put("vanilla_resizable", false);
+    NUMBERED_DIALOGUE_OPTIONS.put("lite", false);
+    NUMBERED_DIALOGUE_OPTIONS.put("default", false);
+    NUMBERED_DIALOGUE_OPTIONS.put("heavy", false);
+    NUMBERED_DIALOGUE_OPTIONS.put("all", true);
+    NUMBERED_DIALOGUE_OPTIONS.put(
+        "custom", getPropBoolean(props, "numbered_dialogue_options", NUMBERED_DIALOGUE_OPTIONS.get("default")));
 
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla", false);
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla_resizable", false);
@@ -2744,6 +2754,7 @@ public class Settings {
           "command_patch_edible_rares", Boolean.toString(COMMAND_PATCH_EDIBLE_RARES.get(preset)));
       props.setProperty("command_patch_disk", Boolean.toString(COMMAND_PATCH_DISK.get(preset)));
       props.setProperty("bypass_attack", Boolean.toString(ATTACK_ALWAYS_LEFT_CLICK.get(preset)));
+      props.setProperty("numbered_dialogue_options", Boolean.toString(NUMBERED_DIALOGUE_OPTIONS.get(preset)));
       props.setProperty(
           "enable_mousewheel_scrolling", Boolean.toString(ENABLE_MOUSEWHEEL_SCROLLING.get(preset)));
       props.setProperty(
@@ -3244,6 +3255,21 @@ public class Settings {
     } else {
       Client.displayMessage(
           "@cya@You are no longer able to left click attack all monsters", Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
+  public static void toggleNumberedDialogue() {
+    NUMBERED_DIALOGUE_OPTIONS.put(
+        currentProfile, new Boolean(!NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)));
+
+    if (NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)) {
+      Client.displayMessage(
+          "@cya@Displaying numbered dialogue options", Client.CHAT_NONE);
+    } else {
+      Client.displayMessage(
+          "@cya@No longer displaying numbered dialogue options", Client.CHAT_NONE);
     }
 
     save();
@@ -3937,6 +3963,9 @@ public class Settings {
         return true;
       case "toggle_bypass_attack":
         Settings.toggleAttackAlwaysLeftClick();
+        return true;
+      case "toggle_numbered_dialogue":
+        Settings.toggleNumberedDialogue();
         return true;
       case "toggle_roof_hiding":
         Settings.toggleHideRoofs();

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2715,6 +2715,14 @@ public class Client {
     if (Settings.PARSE_OPCODES.get(Settings.currentProfile)
         && (Replay.isPlaying || Replay.isSeeking || Replay.isRestarting)) return;
 
+    if (Settings.NUMBERED_DIALOGUE_OPTIONS.get(Settings.currentProfile)) {
+      for (int i = 0; i < 5; i++) {
+        if (menuOptions[i] != null) {
+          menuOptions[i] = "(" + (i + 1) + ") " + menuOptions[i];
+        }
+      }
+    }
+
     Client.printReceivedOptions(menuOptions, count);
   }
 


### PR DESCRIPTION
Adds an option to enable displaying a number behind dialogue options:

<img width="276" alt="numbered_dialogue" src="https://user-images.githubusercontent.com/16803725/219416068-84c29963-eaca-486b-925a-412f3949b7b7.png">