### PR TITLE
Chat history scrolling

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -188,6 +188,7 @@ public class ConfigWindow {
   private JCheckBox generalPanelColoredTextCheckbox;
   private JSlider generalPanelFoVSlider;
   private JCheckBox generalPanelCustomCursorCheckbox;
+  private JCheckBox generalPanelCtrlScrollChatCheckbox;
   private JCheckBox generalPanelShiftScrollCameraRotationCheckbox;
   private JCheckBox generalPanelCustomRandomChatColourCheckbox;
   private JRadioButton generalPanelRanEntirelyDisableButton;
@@ -971,6 +972,11 @@ public class ConfigWindow {
     generalPanelCustomCursorCheckbox.setToolTipText(
         "Switch to using a custom mouse cursor instead of the system default");
 
+    generalPanelCtrlScrollChatCheckbox =
+        addCheckbox("Hold ctrl to scroll through chat history from anywhere", generalPanel);
+    generalPanelCtrlScrollChatCheckbox.setToolTipText(
+        "Holding CTRL allows you to scroll through the currently-selected chat history from anywhere");
+
     generalPanelShiftScrollCameraRotationCheckbox =
         addCheckbox("Enable camera rotation with compatible trackpads", generalPanel);
     generalPanelShiftScrollCameraRotationCheckbox.setToolTipText(
@@ -1409,7 +1415,8 @@ public class ConfigWindow {
         "Left click attack monsters regardless of level difference");
     generalPanelBypassAttackCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
 
-    generalPanelNumberedDialogueOptionsCheckbox = addCheckbox("Display numbers next to dialogue options", generalPanel);
+    generalPanelNumberedDialogueOptionsCheckbox =
+        addCheckbox("Display numbers next to dialogue options", generalPanel);
     generalPanelNumberedDialogueOptionsCheckbox.setToolTipText(
         "Displays a number next to each option within a conversational menu");
 
@@ -2773,7 +2780,12 @@ public class ConfigWindow {
         "toggle_trackpad_camera_rotation",
         KeyModifier.ALT,
         KeyEvent.VK_D);
-
+    addKeybindSet(
+        keybindContainerPanel,
+        "Toggle ctrl to scroll chat history",
+        "toggle_ctrl_scroll",
+        KeyModifier.ALT,
+        KeyEvent.VK_H);
     addKeybindCategory(keybindContainerPanel, "Overlays");
     addKeybindSet(
         keybindContainerPanel,
@@ -3780,6 +3792,8 @@ public class ConfigWindow {
     generalPanelSkyUndergroundColourColourPanel.setBackground(undergroundSkyColour);
     generalPanelCustomCursorCheckbox.setSelected(
         Settings.SOFTWARE_CURSOR.get(Settings.currentProfile));
+    generalPanelCtrlScrollChatCheckbox.setSelected(
+        Settings.CTRL_SCROLL_CHAT.get(Settings.currentProfile));
     generalPanelShiftScrollCameraRotationCheckbox.setSelected(
         Settings.SHIFT_SCROLL_CAMERA_ROTATION.get(Settings.currentProfile));
     generalPanelViewDistanceSlider.setValue(Settings.VIEW_DISTANCE.get(Settings.currentProfile));
@@ -4245,6 +4259,8 @@ public class ConfigWindow {
     Settings.FOV.put(Settings.currentProfile, generalPanelFoVSlider.getValue());
     Settings.SOFTWARE_CURSOR.put(
         Settings.currentProfile, generalPanelCustomCursorCheckbox.isSelected());
+    Settings.CTRL_SCROLL_CHAT.put(
+        Settings.currentProfile, generalPanelCtrlScrollChatCheckbox.isSelected());
     Settings.SHIFT_SCROLL_CAMERA_ROTATION.put(
         Settings.currentProfile, generalPanelShiftScrollCameraRotationCheckbox.isSelected());
     Settings.AUTO_SCREENSHOT.put(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -627,13 +627,15 @@ public class JClassPatcher {
           "Ljava/lang/Object;",
           true,
           false);
-      hookClassVariable(
+      hookClassVariable( // Selected tab
+          methodNode, "client", "Zh", "I", "Game/Menu", "chat_selected", "I", true, false);
+      hookClassVariable( // Chat history
           methodNode, "client", "Fh", "I", "Game/Menu", "chat_type1", "I", true, false);
-      hookClassVariable(
+      hookClassVariable( // All messages
           methodNode, "client", "bh", "I", "Game/Menu", "chat_input", "I", true, false);
-      hookClassVariable(
+      hookClassVariable( // Quest history
           methodNode, "client", "ud", "I", "Game/Menu", "chat_type2", "I", true, false);
-      hookClassVariable(
+      hookClassVariable( // Private history
           methodNode, "client", "mc", "I", "Game/Menu", "chat_type3", "I", true, false);
 
       // Quest menu

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -124,6 +124,7 @@ public class Settings {
   public static HashMap<String, Boolean> FPS_LIMIT_ENABLED = new HashMap<String, Boolean>();
   public static HashMap<String, Integer> FPS_LIMIT = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> SOFTWARE_CURSOR = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> CTRL_SCROLL_CHAT = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHIFT_SCROLL_CAMERA_ROTATION =
       new HashMap<String, Boolean>();
   public static HashMap<String, RanOverrideEffectType> CUSTOM_RAN_CHAT_EFFECT =
@@ -674,7 +675,9 @@ public class Settings {
     NUMBERED_DIALOGUE_OPTIONS.put("heavy", false);
     NUMBERED_DIALOGUE_OPTIONS.put("all", true);
     NUMBERED_DIALOGUE_OPTIONS.put(
-        "custom", getPropBoolean(props, "numbered_dialogue_options", NUMBERED_DIALOGUE_OPTIONS.get("default")));
+        "custom",
+        getPropBoolean(
+            props, "numbered_dialogue_options", NUMBERED_DIALOGUE_OPTIONS.get("default")));
 
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla", false);
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla_resizable", false);
@@ -810,6 +813,15 @@ public class Settings {
     SOFTWARE_CURSOR.put("all", true);
     SOFTWARE_CURSOR.put(
         "custom", getPropBoolean(props, "software_cursor", SOFTWARE_CURSOR.get("default")));
+
+    CTRL_SCROLL_CHAT.put("vanilla", false);
+    CTRL_SCROLL_CHAT.put("vanilla_resizable", false);
+    CTRL_SCROLL_CHAT.put("lite", false);
+    CTRL_SCROLL_CHAT.put("default", true);
+    CTRL_SCROLL_CHAT.put("heavy", true);
+    CTRL_SCROLL_CHAT.put("all", true);
+    CTRL_SCROLL_CHAT.put(
+        "custom", getPropBoolean(props, "ctrl_scroll_chat", CTRL_SCROLL_CHAT.get("default")));
 
     SHIFT_SCROLL_CAMERA_ROTATION.put("vanilla", false);
     SHIFT_SCROLL_CAMERA_ROTATION.put("vanilla_resizable", false);
@@ -2754,7 +2766,8 @@ public class Settings {
           "command_patch_edible_rares", Boolean.toString(COMMAND_PATCH_EDIBLE_RARES.get(preset)));
       props.setProperty("command_patch_disk", Boolean.toString(COMMAND_PATCH_DISK.get(preset)));
       props.setProperty("bypass_attack", Boolean.toString(ATTACK_ALWAYS_LEFT_CLICK.get(preset)));
-      props.setProperty("numbered_dialogue_options", Boolean.toString(NUMBERED_DIALOGUE_OPTIONS.get(preset)));
+      props.setProperty(
+          "numbered_dialogue_options", Boolean.toString(NUMBERED_DIALOGUE_OPTIONS.get(preset)));
       props.setProperty(
           "enable_mousewheel_scrolling", Boolean.toString(ENABLE_MOUSEWHEEL_SCROLLING.get(preset)));
       props.setProperty(
@@ -2776,6 +2789,7 @@ public class Settings {
       props.setProperty("fps_limit_enabled", Boolean.toString(FPS_LIMIT_ENABLED.get(preset)));
       props.setProperty("fps_limit", Integer.toString(FPS_LIMIT.get(preset)));
       props.setProperty("software_cursor", Boolean.toString(SOFTWARE_CURSOR.get(preset)));
+      props.setProperty("ctrl_scroll_chat", Boolean.toString(CTRL_SCROLL_CHAT.get(preset)));
       props.setProperty(
           "shift_scroll_camera_rotation",
           Boolean.toString(SHIFT_SCROLL_CAMERA_ROTATION.get(preset)));
@@ -3265,8 +3279,7 @@ public class Settings {
         currentProfile, new Boolean(!NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)));
 
     if (NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)) {
-      Client.displayMessage(
-          "@cya@Displaying numbered dialogue options", Client.CHAT_NONE);
+      Client.displayMessage("@cya@Displaying numbered dialogue options", Client.CHAT_NONE);
     } else {
       Client.displayMessage(
           "@cya@No longer displaying numbered dialogue options", Client.CHAT_NONE);
@@ -3623,6 +3636,22 @@ public class Settings {
     save();
   }
 
+  public static void toggleCtrlScroll() {
+    CTRL_SCROLL_CHAT.put(currentProfile, !CTRL_SCROLL_CHAT.get(currentProfile));
+
+    if (CTRL_SCROLL_CHAT.get(currentProfile)) {
+      Client.displayMessage(
+          "@cya@Hold CTRL to scroll through chat history from anywhere is now enabled",
+          Client.CHAT_NONE);
+    } else {
+      Client.displayMessage(
+          "@cya@Hold CTRL to scroll through chat history from anywhere is now disabled",
+          Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
   public static void toggleColorTerminal() {
     COLORIZE_CONSOLE_TEXT.put(currentProfile, !COLORIZE_CONSOLE_TEXT.get(currentProfile));
 
@@ -3894,6 +3923,9 @@ public class Settings {
         return true;
       case "toggle_trackpad_camera_rotation":
         Settings.toggleTrackpadRotation();
+        return true;
+      case "toggle_ctrl_scroll":
+        Settings.toggleCtrlScroll();
         return true;
       case "toggle_colorize":
         Settings.toggleColorTerminal();

--- a/src/Game/KeyboardHandler.java
+++ b/src/Game/KeyboardHandler.java
@@ -36,6 +36,7 @@ public class KeyboardHandler implements KeyListener {
   public static boolean keyUp = false;
   public static boolean keyDown = false;
   public static boolean keyShift = false;
+  public static boolean keyControl = false;
 
   /** ArrayList containing all registered KeybindSet values */
   public static ArrayList<KeybindSet> keybindSetList = new ArrayList<KeybindSet>();
@@ -168,6 +169,7 @@ public class KeyboardHandler implements KeyListener {
       }
 
       keyShift = e.isShiftDown();
+      keyControl = e.isControlDown();
     }
 
     if (listener_key != null && !e.isConsumed()) {
@@ -210,6 +212,7 @@ public class KeyboardHandler implements KeyListener {
       }
 
       keyShift = e.isShiftDown();
+      keyControl = e.isControlDown();
     }
 
     if (listener_key != null && !e.isConsumed()) {
@@ -246,6 +249,7 @@ public class KeyboardHandler implements KeyListener {
       }
 
       keyShift = e.isShiftDown();
+      keyControl = e.isControlDown();
     }
 
     if (listener_key != null && !e.isConsumed()) {

--- a/src/Game/Menu.java
+++ b/src/Game/Menu.java
@@ -28,6 +28,7 @@ public class Menu {
   public static int chat_type2;
   public static int chat_type3;
   public static int chat_input;
+  public static int chat_selected;
 
   public static Object quest_menu;
   public static int quest_handle;

--- a/src/Game/MouseHandler.java
+++ b/src/Game/MouseHandler.java
@@ -426,7 +426,7 @@ public class MouseHandler implements MouseListener, MouseMotionListener, MouseWh
     }
 
     // Or hovering over scrollbar bounds
-    chatScrollbarBounds = new Rectangle(Renderer.width - 16, Renderer.height - 75, 12, 58);
+    chatScrollbarBounds = new Rectangle(Renderer.width - 16, Renderer.height - 75, 16, 58);
     return x >= chatScrollbarBounds.x
         && x <= chatScrollbarBounds.x + chatScrollbarBounds.width
         && y >= chatScrollbarBounds.y

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -70,6 +70,7 @@ public class Reflection {
   public static Field menuTextSize = null;
   public static Field menuText = null;
   public static Field menuCount = null;
+  public static Field menuItemArray = null;
 
   public static Field memberMapPack = null;
   public static Field memberLandscapePack = null;
@@ -734,6 +735,7 @@ public class Reflection {
       menuTextSize = c.getDeclaredField("k");
       menuText = c.getDeclaredField("yb");
       menuCount = c.getDeclaredField("eb");
+      menuItemArray = c.getDeclaredField("pb");
       methods = c.getDeclaredMethods();
       for (Method method : methods) {
         if (method.toGenericString().equals(ADDBUTTONBACK)) {
@@ -847,6 +849,7 @@ public class Reflection {
       if (menuTextSize != null) menuTextSize.setAccessible(true);
       if (menuText != null) menuText.setAccessible(true);
       if (menuCount != null) menuCount.setAccessible(true);
+      if (menuItemArray != null) menuItemArray.setAccessible(true);
       if (getParameter != null) getParameter.setAccessible(true);
       if (displayMessage != null) displayMessage.setAccessible(true);
       if (setCameraSize != null) setCameraSize.setAccessible(true);


### PR DESCRIPTION
This PR adds a mouse wheel scroll feature to the chat history tabs:

* Enables the mouse wheel to scroll through chat history when hovering over the scrollbar
* Adds a new option which enables scrolling through chat history regardless of mouse position, when holding CTRL
