### PR TITLE
Toggle for Status Display to Always Show as Text

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1410,7 +1410,8 @@ public class ConfigWindow {
         "Left click attack monsters regardless of level difference");
     generalPanelBypassAttackCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
 
-    generalPanelNumberedDialogueOptionsCheckbox = addCheckbox("Display numbers next to dialogue options", generalPanel);
+    generalPanelNumberedDialogueOptionsCheckbox =
+        addCheckbox("Display numbers next to dialogue options", generalPanel);
     generalPanelNumberedDialogueOptionsCheckbox.setToolTipText(
         "Displays a number next to each option within a conversational menu");
 
@@ -1580,8 +1581,10 @@ public class ConfigWindow {
     overlayPanelStatusDisplayCheckbox.setToolTipText("Toggle hits/prayer/fatigue display");
     overlayPanelStatusDisplayCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
 
-    overlayPanelStatusAlwaysTextCheckbox = addCheckbox("Always show HP/Prayer/Fatigue display in upper-left corner", overlayPanel);
-    overlayPanelStatusAlwaysTextCheckbox.setToolTipText("Always show the status display as text even at larger client sizes");
+    overlayPanelStatusAlwaysTextCheckbox =
+        addCheckbox("Always show HP/Prayer/Fatigue display in upper-left corner", overlayPanel);
+    overlayPanelStatusAlwaysTextCheckbox.setToolTipText(
+        "Always show the status display as text even at larger client sizes");
 
     overlayPanelBuffsCheckbox =
         addCheckbox("Show combat (de)buffs and cooldowns display", overlayPanel);

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -224,6 +224,7 @@ public class ConfigWindow {
 
   //// Overlays tab
   private JCheckBox overlayPanelStatusDisplayCheckbox;
+  private JCheckBox overlayPanelStatusAlwaysTextCheckbox;
   private JCheckBox overlayPanelBuffsCheckbox;
   private JCheckBox overlayPanelLastMenuActionCheckbox;
   private JCheckBox overlayPanelMouseTooltipCheckbox;
@@ -1578,6 +1579,9 @@ public class ConfigWindow {
     overlayPanelStatusDisplayCheckbox = addCheckbox("Show HP/Prayer/Fatigue display", overlayPanel);
     overlayPanelStatusDisplayCheckbox.setToolTipText("Toggle hits/prayer/fatigue display");
     overlayPanelStatusDisplayCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
+
+    overlayPanelStatusAlwaysTextCheckbox = addCheckbox("Always show HP/Prayer/Fatigue display in upper-left corner", overlayPanel);
+    overlayPanelStatusAlwaysTextCheckbox.setToolTipText("Always show the status display as text even at larger client sizes");
 
     overlayPanelBuffsCheckbox =
         addCheckbox("Show combat (de)buffs and cooldowns display", overlayPanel);
@@ -3852,6 +3856,8 @@ public class ConfigWindow {
     // Overlays tab
     overlayPanelStatusDisplayCheckbox.setSelected(
         Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile));
+    overlayPanelStatusAlwaysTextCheckbox.setSelected(
+        Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile));
     overlayPanelBuffsCheckbox.setSelected(Settings.SHOW_BUFFS.get(Settings.currentProfile));
     overlayPanelLastMenuActionCheckbox.setSelected(
         Settings.SHOW_LAST_MENU_ACTION.get(Settings.currentProfile));
@@ -4281,6 +4287,8 @@ public class ConfigWindow {
     // Overlays options
     Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.put(
         Settings.currentProfile, overlayPanelStatusDisplayCheckbox.isSelected());
+    Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put(
+        Settings.currentProfile, overlayPanelStatusAlwaysTextCheckbox.isSelected());
     Settings.SHOW_BUFFS.put(Settings.currentProfile, overlayPanelBuffsCheckbox.isSelected());
     Settings.SHOW_LAST_MENU_ACTION.put(
         Settings.currentProfile, overlayPanelLastMenuActionCheckbox.isSelected());

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -676,7 +676,9 @@ public class Settings {
     NUMBERED_DIALOGUE_OPTIONS.put("heavy", false);
     NUMBERED_DIALOGUE_OPTIONS.put("all", true);
     NUMBERED_DIALOGUE_OPTIONS.put(
-        "custom", getPropBoolean(props, "numbered_dialogue_options", NUMBERED_DIALOGUE_OPTIONS.get("default")));
+        "custom",
+        getPropBoolean(
+            props, "numbered_dialogue_options", NUMBERED_DIALOGUE_OPTIONS.get("default")));
 
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla", false);
     ENABLE_MOUSEWHEEL_SCROLLING.put("vanilla_resizable", false);
@@ -1465,7 +1467,10 @@ public class Settings {
     ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("all", false);
     ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put(
         "custom",
-        getPropBoolean(props, "always_show_statusdisplay_text", ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get("default")));
+        getPropBoolean(
+            props,
+            "always_show_statusdisplay_text",
+            ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get("default")));
 
     SHOW_BUFFS.put("vanilla", false);
     SHOW_BUFFS.put("vanilla_resizable", false);
@@ -2766,7 +2771,8 @@ public class Settings {
           "command_patch_edible_rares", Boolean.toString(COMMAND_PATCH_EDIBLE_RARES.get(preset)));
       props.setProperty("command_patch_disk", Boolean.toString(COMMAND_PATCH_DISK.get(preset)));
       props.setProperty("bypass_attack", Boolean.toString(ATTACK_ALWAYS_LEFT_CLICK.get(preset)));
-      props.setProperty("numbered_dialogue_options", Boolean.toString(NUMBERED_DIALOGUE_OPTIONS.get(preset)));
+      props.setProperty(
+          "numbered_dialogue_options", Boolean.toString(NUMBERED_DIALOGUE_OPTIONS.get(preset)));
       props.setProperty(
           "enable_mousewheel_scrolling", Boolean.toString(ENABLE_MOUSEWHEEL_SCROLLING.get(preset)));
       props.setProperty(
@@ -2897,7 +2903,8 @@ public class Settings {
       props.setProperty(
           "show_statusdisplay", Boolean.toString(SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(preset)));
       props.setProperty(
-          "always_show_statusdisplay_text", Boolean.toString(ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(preset)));
+          "always_show_statusdisplay_text",
+          Boolean.toString(ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(preset)));
       props.setProperty("show_buffs", Boolean.toString(SHOW_BUFFS.get(preset)));
       props.setProperty(
           "show_last_menu_action", Boolean.toString(SHOW_LAST_MENU_ACTION.get(preset)));
@@ -3279,8 +3286,7 @@ public class Settings {
         currentProfile, new Boolean(!NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)));
 
     if (NUMBERED_DIALOGUE_OPTIONS.get(currentProfile)) {
-      Client.displayMessage(
-          "@cya@Displaying numbered dialogue options", Client.CHAT_NONE);
+      Client.displayMessage("@cya@Displaying numbered dialogue options", Client.CHAT_NONE);
     } else {
       Client.displayMessage(
           "@cya@No longer displaying numbered dialogue options", Client.CHAT_NONE);
@@ -3429,19 +3435,6 @@ public class Settings {
       Client.displayMessage("@cya@HP/Prayer/Fatigue are now shown", Client.CHAT_NONE);
     } else {
       Client.displayMessage("@cya@HP/Prayer/Fatigue are now hidden", Client.CHAT_NONE);
-    }
-
-    save();
-  }
-
-  public static void toggleHpPrayerFatigueOverlayAlwaysText() {
-    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put(
-        currentProfile, !ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(currentProfile));
-
-    if (ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(currentProfile)) {
-      Client.displayMessage("@cya@HP/Prayer/Fatigue will always show as text", Client.CHAT_NONE);
-    } else {
-      Client.displayMessage("@cya@HP/Prayer/Fatigue will no longer always show as text", Client.CHAT_NONE);
     }
 
     save();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -202,6 +202,8 @@ public class Settings {
   //// overlays
   public static HashMap<String, Boolean> SHOW_HP_PRAYER_FATIGUE_OVERLAY =
       new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT =
+      new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_MOUSE_TOOLTIP = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_EXTENDED_TOOLTIP = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_BUFFS = new HashMap<String, Boolean>();
@@ -1454,6 +1456,16 @@ public class Settings {
     SHOW_HP_PRAYER_FATIGUE_OVERLAY.put(
         "custom",
         getPropBoolean(props, "show_statusdisplay", SHOW_HP_PRAYER_FATIGUE_OVERLAY.get("default")));
+
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("vanilla", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("vanilla_resizable", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("lite", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("default", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("heavy", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put("all", false);
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put(
+        "custom",
+        getPropBoolean(props, "always_show_statusdisplay_text", ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get("default")));
 
     SHOW_BUFFS.put("vanilla", false);
     SHOW_BUFFS.put("vanilla_resizable", false);
@@ -2884,6 +2896,8 @@ public class Settings {
       //// overlays
       props.setProperty(
           "show_statusdisplay", Boolean.toString(SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(preset)));
+      props.setProperty(
+          "always_show_statusdisplay_text", Boolean.toString(ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(preset)));
       props.setProperty("show_buffs", Boolean.toString(SHOW_BUFFS.get(preset)));
       props.setProperty(
           "show_last_menu_action", Boolean.toString(SHOW_LAST_MENU_ACTION.get(preset)));
@@ -3415,6 +3429,19 @@ public class Settings {
       Client.displayMessage("@cya@HP/Prayer/Fatigue are now shown", Client.CHAT_NONE);
     } else {
       Client.displayMessage("@cya@HP/Prayer/Fatigue are now hidden", Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
+  public static void toggleHpPrayerFatigueOverlayAlwaysText() {
+    ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.put(
+        currentProfile, !ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(currentProfile));
+
+    if (ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(currentProfile)) {
+      Client.displayMessage("@cya@HP/Prayer/Fatigue will always show as text", Client.CHAT_NONE);
+    } else {
+      Client.displayMessage("@cya@HP/Prayer/Fatigue will no longer always show as text", Client.CHAT_NONE);
     }
 
     save();

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -3508,7 +3508,7 @@ public class Client {
       // both wiki lookup and report abuse button are enabled
       // want to make room for hp/prayer/fatigue overlay if possible
       if (Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile)
-      && !Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)) {
+          && !Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)) {
         // there is a 90 pixel region where HP/Prayer/Fatigue overlay can't be drawn, but both
         // Report Abuse & Wiki lookup can
         return (Renderer.width < 900 && Renderer.width >= 704) || Renderer.width < 512 + 90 + 12;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -3507,7 +3507,8 @@ public class Client {
       }
       // both wiki lookup and report abuse button are enabled
       // want to make room for hp/prayer/fatigue overlay if possible
-      if (Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile)) {
+      if (Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile)
+      && !Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)) {
         // there is a 90 pixel region where HP/Prayer/Fatigue overlay can't be drawn, but both
         // Report Abuse & Wiki lookup can
         return (Renderer.width < 900 && Renderer.width >= 704) || Renderer.width < 512 + 90 + 12;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -690,7 +690,7 @@ public class Renderer {
       }
 
       if (Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile)) {
-        if (!roomInHbarForHPPrayerFatigueOverlay()) {
+        if (!roomInHbarForHPPrayerFatigueOverlay() || Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)) {
           if (!Client.isInterfaceOpen() && !Client.show_questionmenu) {
             setAlpha(g2, alphaHP);
             drawShadowText(

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -690,7 +690,8 @@ public class Renderer {
       }
 
       if (Settings.SHOW_HP_PRAYER_FATIGUE_OVERLAY.get(Settings.currentProfile)) {
-        if (!roomInHbarForHPPrayerFatigueOverlay() || Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)) {
+        if (Settings.ALWAYS_SHOW_HP_PRAYER_FATIGUE_AS_TEXT.get(Settings.currentProfile)
+            || !roomInHbarForHPPrayerFatigueOverlay()) {
           if (!Client.isInterfaceOpen() && !Client.show_questionmenu) {
             setAlpha(g2, alphaHP);
             drawShadowText(


### PR DESCRIPTION
Added a toggle to have the HP/Prayer/Fatigue display always show as text instead of bars.