### PR TITLE
Adjustable sfx volume

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -265,6 +265,7 @@ public class ConfigWindow {
 
   //// Audio tab
   private JCheckBox audioPanelEnableMusicCheckbox;
+  private JSlider audioPanelSfxVolumeSlider;
   private JCheckBox audioPanelLouderSoundEffectsCheckbox;
   private JCheckBox audioPanelOverrideAudioSettingCheckbox;
   private JRadioButton audioPanelOverrideAudioSettingOnButton;
@@ -1837,9 +1838,36 @@ public class ConfigWindow {
     audioPanelEnableMusicCheckbox.setToolTipText("Enable Music (Must have music pack installed)");
     audioPanelEnableMusicCheckbox.setBorder(new EmptyBorder(7, 0, 10, 0));
 
+    JLabel audioPanelSfxVolumeLabel = new JLabel("Sound effects volume");
+    audioPanelSfxVolumeLabel.setToolTipText("Sets the volume for game sound effects");
+    audioPanelSfxVolumeLabel.setBorder(new EmptyBorder(7, 0, 0, 0));
+    audioPanel.add(audioPanelSfxVolumeLabel);
+    audioPanelSfxVolumeLabel.setAlignmentY((float) 1);
+
+    audioPanelSfxVolumeSlider = new JSlider();
+
+    audioPanel.add(audioPanelSfxVolumeSlider);
+    audioPanelSfxVolumeSlider.setAlignmentX(Component.LEFT_ALIGNMENT);
+    audioPanelSfxVolumeSlider.setMaximumSize(new Dimension(350, 55));
+    audioPanelSfxVolumeSlider.setBorder(new EmptyBorder(0, 0, 15, 0));
+    audioPanelSfxVolumeSlider.setMinorTickSpacing(5);
+    audioPanelSfxVolumeSlider.setMajorTickSpacing(10);
+    audioPanelSfxVolumeSlider.setMinimum(0);
+    audioPanelSfxVolumeSlider.setMaximum(100);
+    audioPanelSfxVolumeSlider.setPaintTicks(true);
+
+    Hashtable<Integer, JLabel> audioPanelSfxVolumeTable = new Hashtable<Integer, JLabel>();
+    audioPanelSfxVolumeTable.put(new Integer(0), new JLabel("0"));
+    audioPanelSfxVolumeTable.put(new Integer(25), new JLabel("25"));
+    audioPanelSfxVolumeTable.put(new Integer(50), new JLabel("50"));
+    audioPanelSfxVolumeTable.put(new Integer(75), new JLabel("75"));
+    audioPanelSfxVolumeTable.put(new Integer(100), new JLabel("100"));
+    audioPanelSfxVolumeSlider.setLabelTable(audioPanelSfxVolumeTable);
+    audioPanelSfxVolumeSlider.setPaintLabels(true);
+
     audioPanelLouderSoundEffectsCheckbox = addCheckbox("Louder sound effects", audioPanel);
     audioPanelLouderSoundEffectsCheckbox.setToolTipText(
-        "Play sound effects twice at the same time so that it's louder.");
+        "Doubles the current volume for all sound effects.");
 
     audioPanelOverrideAudioSettingCheckbox =
         addCheckbox("Override server's remembered audio on/off setting", audioPanel);
@@ -3941,6 +3969,7 @@ public class ConfigWindow {
 
     // Audio tab
     audioPanelEnableMusicCheckbox.setSelected(Settings.CUSTOM_MUSIC.get(Settings.currentProfile));
+    audioPanelSfxVolumeSlider.setValue(Settings.SFX_VOLUME.get(Settings.currentProfile));
     audioPanelLouderSoundEffectsCheckbox.setSelected(
         Settings.LOUDER_SOUND_EFFECTS.get(Settings.currentProfile));
     audioPanelOverrideAudioSettingCheckbox.setSelected(
@@ -4359,6 +4388,7 @@ public class ConfigWindow {
 
     // Audio options
     Settings.CUSTOM_MUSIC.put(Settings.currentProfile, audioPanelEnableMusicCheckbox.isSelected());
+    Settings.SFX_VOLUME.put(Settings.currentProfile, audioPanelSfxVolumeSlider.getValue());
     Settings.LOUDER_SOUND_EFFECTS.put(
         Settings.currentProfile, audioPanelLouderSoundEffectsCheckbox.isSelected());
     Settings.OVERRIDE_AUDIO_SETTING.put(
@@ -4640,6 +4670,7 @@ public class ConfigWindow {
     Item.patchItemNames();
     Item.patchItemCommands();
     GameApplet.syncFontSetting();
+    SoundEffects.adjustMudClientSfxVolume();
   }
 
   public void synchronizePresetOptions() {

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -514,6 +514,16 @@ public class JClassPatcher {
           methodNode, "client", "Kg", "Z", "Game/Client", "show_appearance", "Z", true, true);
       hookClassVariable(
           methodNode, "client", "ne", "Z", "Game/SoundEffects", "sounds_disabled", "Z", true, true);
+      hookClassVariable(
+          methodNode,
+          "pb",
+          "w",
+          "Ljavax/sound/sampled/SourceDataLine;",
+          "Game/SoundEffects",
+          "mudClientSourceDataLine",
+          "Ljavax/sound/sampled/SourceDataLine;",
+          true,
+          true);
 
       hookClassVariable(
           methodNode,

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -507,14 +507,14 @@ public class ScaledWindow extends JFrame
   public void mouseEntered(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseEntered(mapMouseEvent(e));
+    Client.handler_mouse.mouseEntered(e);
   }
 
   @Override
   public void mouseExited(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseExited(mapMouseEvent(e));
+    Client.handler_mouse.mouseExited(e);
   }
 
   @Override

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -507,14 +507,14 @@ public class ScaledWindow extends JFrame
   public void mouseEntered(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseEntered(e);
+    Client.handler_mouse.mouseEntered(mapMouseEvent(e));
   }
 
   @Override
   public void mouseExited(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseExited(e);
+    Client.handler_mouse.mouseExited(mapMouseEvent(e));
   }
 
   @Override

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2345,6 +2345,14 @@ public class Settings {
       save("custom");
     }
 
+    if (SFX_VOLUME.get("custom") < 0) {
+      SFX_VOLUME.put("custom", 0);
+      save("custom");
+    } else if (SFX_VOLUME.get("custom") > 100) {
+      SFX_VOLUME.put("custom", 100);
+      save("custom");
+    }
+
     if (VIEW_DISTANCE.get("custom") < 2300) {
       VIEW_DISTANCE.put("custom", 2300);
       save("custom");

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -26,6 +26,7 @@ import Game.Game;
 import Game.KeyboardHandler;
 import Game.Renderer;
 import Game.Replay;
+import Game.SoundEffects;
 import Game.XPBar;
 import java.awt.Cursor;
 import java.awt.Point;
@@ -153,10 +154,11 @@ public class Settings {
   public static HashMap<String, Boolean> LOG_FORCE_LEVEL = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> PREFERS_XDG_OPEN = new HashMap<String, Boolean>();
 
-  //// music
+  //// audio settings
   public static HashMap<String, String> CUSTOM_MUSIC_PATH = new HashMap<String, String>();
   public static final double MIDI_VOLUME = 0.01;
   public static HashMap<String, Boolean> CUSTOM_MUSIC = new HashMap<String, Boolean>();
+  public static HashMap<String, Integer> SFX_VOLUME = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> LOUDER_SOUND_EFFECTS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> OVERRIDE_AUDIO_SETTING = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> OVERRIDE_AUDIO_SETTING_SETTING_ON =
@@ -1036,7 +1038,7 @@ public class Settings {
     PREFERS_XDG_OPEN.put(
         "custom", getPropBoolean(props, "prefers_xdg_open", PREFERS_XDG_OPEN.get("default")));
 
-    //// music
+    //// audio settings
     CUSTOM_MUSIC.put("vanilla", false);
     CUSTOM_MUSIC.put("vanilla_resizable", false);
     CUSTOM_MUSIC.put("lite", false);
@@ -1053,6 +1055,15 @@ public class Settings {
     CUSTOM_MUSIC_PATH.put("all", CUSTOM_MUSIC_PATH.get("vanilla"));
     CUSTOM_MUSIC_PATH.put(
         "custom", getPropString(props, "custom_music_path", CUSTOM_MUSIC_PATH.get("default")));
+
+    SFX_VOLUME.put("vanilla", 100);
+    SFX_VOLUME.put("vanilla_resizable", 100);
+    SFX_VOLUME.put("lite", 100);
+    SFX_VOLUME.put("default", 100);
+    SFX_VOLUME.put("heavy", 100);
+    SFX_VOLUME.put("all", 100);
+    SFX_VOLUME.put("custom", 100);
+    SFX_VOLUME.put("custom", getPropInt(props, "sfx_volume", SFX_VOLUME.get("default")));
 
     LOUDER_SOUND_EFFECTS.put("vanilla", false);
     LOUDER_SOUND_EFFECTS.put("vanilla_resizable", false);
@@ -2827,9 +2838,10 @@ public class Settings {
       props.setProperty("log_force_level", Boolean.toString(LOG_FORCE_LEVEL.get(preset)));
       props.setProperty("prefers_xdg_open", Boolean.toString(PREFERS_XDG_OPEN.get(preset)));
 
-      //// music
+      //// audio settings
       props.setProperty("custom_music", Boolean.toString(CUSTOM_MUSIC.get(preset)));
       props.setProperty("custom_music_path", CUSTOM_MUSIC_PATH.get(preset));
+      props.setProperty("sfx_volume", Integer.toString(SFX_VOLUME.get(preset)));
       props.setProperty("louder_sound_effects", Boolean.toString(LOUDER_SOUND_EFFECTS.get(preset)));
       props.setProperty(
           "override_audio_setting", Boolean.toString(OVERRIDE_AUDIO_SETTING.get(preset)));
@@ -3771,6 +3783,32 @@ public class Settings {
       Client.displayMessage(
           "@whi@Please use an @lre@integer@whi@ between 7 and 16 (default = 9)", Client.CHAT_QUEST);
     }
+    save();
+  }
+
+  public static void setSfxVolume(String volumeLevel) {
+    String outOfBoundsMessage =
+        "@whi@Please use an @lre@integer@whi@ between 0 and 100 (default = 100)";
+
+    try {
+      int newVolume = Integer.parseInt(volumeLevel);
+
+      // Warn if value out of bounds
+      if (newVolume < 0 || newVolume > 100) {
+        Client.displayMessage(outOfBoundsMessage, Client.CHAT_QUEST);
+        return;
+      }
+
+      SFX_VOLUME.put(currentProfile, newVolume);
+      SoundEffects.adjustMudClientSfxVolume();
+      Client.displayMessage(
+          "@cya@Volume of sound effects was changed to " + volumeLevel + "%", Client.CHAT_NONE);
+
+      Launcher.getConfigWindow().synchronizeGuiValues();
+    } catch (Exception e) {
+      Client.displayMessage(outOfBoundsMessage, Client.CHAT_QUEST);
+    }
+
     save();
   }
 

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -1219,6 +1219,9 @@ public class Client {
     state = STATE_GAME;
     // bank_active_page = 0; // TODO: config option? don't think this is very important.
     // combat_timer = 0;
+
+    // Set the client volume
+    SoundEffects.adjustMudClientSfxVolume();
   }
 
   public static void login_hook() {
@@ -1889,6 +1892,11 @@ public class Client {
               break;
             }
           }
+        case "sfx_volume":
+          if (commandArray.length > 1) {
+            Settings.setSfxVolume(commandArray[1]);
+          }
+          break;
         default:
           if (commandArray[0] != null) {
             return "::";

--- a/src/Game/MusicPlayer.java
+++ b/src/Game/MusicPlayer.java
@@ -60,7 +60,7 @@ public class MusicPlayer implements Runnable {
               try {
                 if (null != input) {
                   Logger.Info("Loading " + switchTrack.filename + "." + switchTrack.filetype);
-                  Sound.play(Sound.loadSound(new BufferedInputStream(input)));
+                  Sound.play(Sound.loadSound(new BufferedInputStream(input)), false);
                 }
               } catch (UnsupportedAudioFileException | IOException e) {
                 e.printStackTrace();

--- a/src/Game/Sound.java
+++ b/src/Game/Sound.java
@@ -56,7 +56,7 @@ public class Sound {
     return new Sound(samples, decodedFormat);
   }
 
-  public static void play(Sound sound) {
+  public static void play(Sound sound, boolean isSoundEffect) {
     InputStream source = new ByteArrayInputStream(sound.getSamples());
     AudioFormat format = sound.getFormat();
     // use a short, 100ms (1/10th sec) buffer for real-time changes to the sound stream
@@ -69,6 +69,10 @@ public class Sound {
       DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
       line = (SourceDataLine) AudioSystem.getLine(info);
       line.open(format, bufferSize);
+
+      if (isSoundEffect) {
+        SoundEffects.adjustSfxVolume(line);
+      }
     } catch (LineUnavailableException ex) {
       ex.printStackTrace();
       return;


### PR DESCRIPTION
Adds a slider to the settings audio panel, allowing a user to adjust the output volume for game sound effects:

<img width="375" alt="Screenshot 2023-02-22 at 9 47 20 PM" src="https://user-images.githubusercontent.com/16803725/220817225-61fd75c2-7703-479d-868b-5d8e1ac37ec6.png">

Sfx volume may also be set with the `::sfx_volume` command.

Additionally, removed the "double sound" implementation for louder sound effects in lieu of the new methodology.