### PR TITLE
misc macos scaling fixes

### DIFF
--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -436,10 +436,13 @@ public class Launcher extends JFrame implements Runnable {
   }
 
   public static void main(String[] args) {
-    // Do this before anything else runs to override OS-level
-    // dpi settings, since we have in-client scaling now
-    System.setProperty("sun.java2d.uiScale.enabled", "false");
-    System.setProperty("sun.java2d.uiScale", "1");
+    // Do this before anything else runs to override OS-level dpi settings,
+    // since we have in-client scaling now (not applicable to macOS, which
+    // implements OS-scaling in a different fashion)
+    if (!Util.isMacOS()) {
+      System.setProperty("sun.java2d.uiScale.enabled", "false");
+      System.setProperty("sun.java2d.uiScale", "1");
+    }
 
     numCores = Runtime.getRuntime().availableProcessors();
 

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -40,6 +40,7 @@ public class ScaledWindow extends JFrame
   // Singleton
   private static ScaledWindow instance = null;
   private static boolean initialRender = true;
+  private static boolean isMacOS = false;
   private static boolean shouldRealign = false;
   private int frameWidth = 0;
   private int frameHeight = 0;
@@ -104,7 +105,9 @@ public class ScaledWindow extends JFrame
     setDropTarget(ReplayQueue.dropReplays);
 
     // Enable macOS fullscreen button, if possible
-    if (Util.isMacOS()) {
+    isMacOS = Util.isMacOS();
+
+    if (isMacOS) {
       try {
         Class util = Class.forName("com.apple.eawt.FullScreenUtilities");
         Class params[] = new Class[] {Window.class, Boolean.TYPE};
@@ -466,6 +469,8 @@ public class ScaledWindow extends JFrame
   @Override
   public void componentResized(ComponentEvent e) {
     resizeApplet();
+    frameWidth = e.getComponent().getWidth();
+    frameHeight = e.getComponent().getHeight();
   }
 
   @Override
@@ -688,6 +693,12 @@ public class ScaledWindow extends JFrame
       // Nearest-neighbor scaling performs roughly 3x better when resized via drawImage(),
       // whereas interpolation scaling performs better using AffineTransformOp.
       if (isIntegerScaling()) {
+        // Workaround for direct drawImage warping which seems to only
+        // affect macOS on JDK 19
+        if (isMacOS && Settings.javaVersion >= 19) {
+          g.setClip(0, 0, newWidth, newHeight);
+        }
+
         g.drawImage(viewportImage, 0, 0, newWidth, newHeight, null);
       } else {
         if (interpolationBackground == null) {


### PR DESCRIPTION
Two small fixes for client scaling, targeting macOS:

* The logic I had previously added which forcibly disables java's own UI scaling seems to have a strange effect on macOS, particularly on Java 11+, where all `Graphics` images become blurry. To work around this, I now perform an OS check before setting the property.
* Specific to macOS and JDK 19, integer scaling via `drawImage` seems to forcibly override the provided width and height values, when the final image is larger than the displayable area. I discovered a fix to prevent this behavior, by setting the `clip` property on the `Graphics` object to the expected bounds.