### PR TITLE
Option to disable alching nat runes

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1422,9 +1422,9 @@ public class ConfigWindow {
         "Displays a number next to each option within a conversational menu");
 
     generalPanelDisableNatureRuneAlchCheckbox =
-            addCheckbox("Disable the ability to cast alchemy spells on nature runes", generalPanel);
+        addCheckbox("Disable the ability to cast alchemy spells on nature runes", generalPanel);
     generalPanelDisableNatureRuneAlchCheckbox.setToolTipText(
-            "Protect yourself from a terrible fate");
+        "Protect yourself from a terrible fate");
 
     generalPanelCommandPatchEdibleRaresCheckbox =
         addCheckbox("Disable the ability to ingest holiday items or rares", generalPanel);
@@ -3742,7 +3742,7 @@ public class ConfigWindow {
     generalPanelNamePatchModeSlider.setValue(Settings.NAME_PATCH_TYPE.get(Settings.currentProfile));
     generalPanelLogVerbositySlider.setValue(Settings.LOG_VERBOSITY.get(Settings.currentProfile));
     generalPanelDisableNatureRuneAlchCheckbox.setSelected(
-            Settings.DISABLE_NAT_RUNE_ALCH.get(Settings.currentProfile));
+        Settings.DISABLE_NAT_RUNE_ALCH.get(Settings.currentProfile));
     generalPanelCommandPatchQuestCheckbox.setSelected(
         Settings.COMMAND_PATCH_QUEST.get(Settings.currentProfile));
     generalPanelCommandPatchEdibleRaresCheckbox.setSelected(
@@ -4242,7 +4242,7 @@ public class ConfigWindow {
     Settings.COMMAND_PATCH_QUEST.put(
         Settings.currentProfile, generalPanelCommandPatchQuestCheckbox.isSelected());
     Settings.DISABLE_NAT_RUNE_ALCH.put(
-            Settings.currentProfile, generalPanelDisableNatureRuneAlchCheckbox.isSelected());
+        Settings.currentProfile, generalPanelDisableNatureRuneAlchCheckbox.isSelected());
     Settings.ATTACK_ALWAYS_LEFT_CLICK.put(
         Settings.currentProfile, generalPanelBypassAttackCheckbox.isSelected());
     Settings.NUMBERED_DIALOGUE_OPTIONS.put(

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -171,6 +171,7 @@ public class ConfigWindow {
   private JCheckBox generalPanelLogForceLevelCheckbox;
   private JCheckBox generalPanelPrefersXdgOpenCheckbox;
   private JCheckBox generalPanelLogForceTimestampsCheckbox;
+  private JCheckBox generalPanelDisableNatureRuneAlchCheckbox;
   private JCheckBox generalPanelCommandPatchQuestCheckbox;
   private JCheckBox generalPanelCommandPatchEdibleRaresCheckbox;
   private JCheckBox generalPanelCommandPatchDiskOfReturningCheckbox;
@@ -1419,6 +1420,11 @@ public class ConfigWindow {
         addCheckbox("Display numbers next to dialogue options", generalPanel);
     generalPanelNumberedDialogueOptionsCheckbox.setToolTipText(
         "Displays a number next to each option within a conversational menu");
+
+    generalPanelDisableNatureRuneAlchCheckbox =
+            addCheckbox("Disable the ability to cast alchemy spells on nature runes", generalPanel);
+    generalPanelDisableNatureRuneAlchCheckbox.setToolTipText(
+            "Protect yourself from a terrible fate");
 
     generalPanelCommandPatchEdibleRaresCheckbox =
         addCheckbox("Disable the ability to ingest holiday items or rares", generalPanel);
@@ -3735,6 +3741,8 @@ public class ConfigWindow {
         Settings.INVENTORY_FULL_ALERT.get(Settings.currentProfile));
     generalPanelNamePatchModeSlider.setValue(Settings.NAME_PATCH_TYPE.get(Settings.currentProfile));
     generalPanelLogVerbositySlider.setValue(Settings.LOG_VERBOSITY.get(Settings.currentProfile));
+    generalPanelDisableNatureRuneAlchCheckbox.setSelected(
+            Settings.DISABLE_NAT_RUNE_ALCH.get(Settings.currentProfile));
     generalPanelCommandPatchQuestCheckbox.setSelected(
         Settings.COMMAND_PATCH_QUEST.get(Settings.currentProfile));
     generalPanelCommandPatchEdibleRaresCheckbox.setSelected(
@@ -4233,6 +4241,8 @@ public class ConfigWindow {
         Settings.currentProfile, generalPanelCommandPatchEdibleRaresCheckbox.isSelected());
     Settings.COMMAND_PATCH_QUEST.put(
         Settings.currentProfile, generalPanelCommandPatchQuestCheckbox.isSelected());
+    Settings.DISABLE_NAT_RUNE_ALCH.put(
+            Settings.currentProfile, generalPanelDisableNatureRuneAlchCheckbox.isSelected());
     Settings.ATTACK_ALWAYS_LEFT_CLICK.put(
         Settings.currentProfile, generalPanelBypassAttackCheckbox.isSelected());
     Settings.NUMBERED_DIALOGUE_OPTIONS.put(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2869,6 +2869,54 @@ public class JClassPatcher {
             break;
           }
         }
+
+        // patch nature rune alching
+        LabelNode itemLabel = new LabelNode();
+        LabelNode originalLabel = new LabelNode();
+        LabelNode skipLabel = new LabelNode();
+
+
+        insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+
+          if (insnNode.getOpcode() == Opcodes.ICONST_4) {
+            insnNode = insnNodeList.next().getPrevious().getPrevious().getPrevious();
+
+            methodNode.instructions.insertBefore(insnNode, new MethodInsnNode(Opcodes.INVOKESTATIC, "Client/Settings", "updateInjectedVariables", "()V", false));
+            methodNode.instructions.insertBefore(insnNode, new FieldInsnNode(Opcodes.GETSTATIC, "Client/Settings", "PROTECT_NAT_RUNE_ALCH_BOOL", "Z"));
+            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IFEQ, originalLabel));
+            methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 5));
+            methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 10));
+            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPEQ, itemLabel));
+            methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 5));
+            methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 28));
+            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
+            methodNode.instructions.insertBefore(insnNode, itemLabel);
+            methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "vf", "[I"));
+            methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 4));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.IALOAD));
+            methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 40));
+            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
+            methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
+            methodNode.instructions.insertBefore(insnNode, new LdcInsnNode("@whi@Nature rune alchemy protection is currently enabled"));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_3));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
+            methodNode.instructions.insertBefore(insnNode, new MethodInsnNode(Opcodes.INVOKESPECIAL, "client", "a", "(ZLjava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;)V", false));
+            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.GOTO, skipLabel));
+            methodNode.instructions.insertBefore(insnNode, originalLabel);
+            for (int i = 0; i < 21; i++) insnNode = insnNode.getNext();
+            methodNode.instructions.insertBefore(insnNode, skipLabel);
+
+            break;
+          }
+        }
       }
 
       if (methodNode.name.equals("b") && methodNode.desc.equals("(IBI)V")) {

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2875,7 +2875,6 @@ public class JClassPatcher {
         LabelNode originalLabel = new LabelNode();
         LabelNode skipLabel = new LabelNode();
 
-
         insnNodeList = methodNode.instructions.iterator();
         while (insnNodeList.hasNext()) {
           AbstractInsnNode insnNode = insnNodeList.next();
@@ -2883,33 +2882,58 @@ public class JClassPatcher {
           if (insnNode.getOpcode() == Opcodes.ICONST_4) {
             insnNode = insnNodeList.next().getPrevious().getPrevious().getPrevious();
 
-            methodNode.instructions.insertBefore(insnNode, new MethodInsnNode(Opcodes.INVOKESTATIC, "Client/Settings", "updateInjectedVariables", "()V", false));
-            methodNode.instructions.insertBefore(insnNode, new FieldInsnNode(Opcodes.GETSTATIC, "Client/Settings", "PROTECT_NAT_RUNE_ALCH_BOOL", "Z"));
-            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IFEQ, originalLabel));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new MethodInsnNode(
+                    Opcodes.INVOKESTATIC,
+                    "Client/Settings",
+                    "updateInjectedVariables",
+                    "()V",
+                    false));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new FieldInsnNode(
+                    Opcodes.GETSTATIC, "Client/Settings", "PROTECT_NAT_RUNE_ALCH_BOOL", "Z"));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.IFEQ, originalLabel));
             methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 5));
             methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 10));
-            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPEQ, itemLabel));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.IF_ICMPEQ, itemLabel));
             methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 5));
             methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 28));
-            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
             methodNode.instructions.insertBefore(insnNode, itemLabel);
             methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
-            methodNode.instructions.insertBefore(insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "vf", "[I"));
+            methodNode.instructions.insertBefore(
+                insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "vf", "[I"));
             methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 4));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.IALOAD));
             methodNode.instructions.insertBefore(insnNode, new IntInsnNode(Opcodes.SIPUSH, 40));
-            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.IF_ICMPNE, originalLabel));
             methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
-            methodNode.instructions.insertBefore(insnNode, new LdcInsnNode("@whi@Nature rune alchemy protection is currently enabled"));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new LdcInsnNode("@whi@Nature rune alchemy protection is currently enabled"));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_3));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ACONST_NULL));
-            methodNode.instructions.insertBefore(insnNode, new MethodInsnNode(Opcodes.INVOKESPECIAL, "client", "a", "(ZLjava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;)V", false));
-            methodNode.instructions.insertBefore(insnNode, new JumpInsnNode(Opcodes.GOTO, skipLabel));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new MethodInsnNode(
+                    Opcodes.INVOKESPECIAL,
+                    "client",
+                    "a",
+                    "(ZLjava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;)V",
+                    false));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.GOTO, skipLabel));
             methodNode.instructions.insertBefore(insnNode, originalLabel);
             for (int i = 0; i < 21; i++) insnNode = insnNode.getNext();
             methodNode.instructions.insertBefore(insnNode, skipLabel);

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2871,15 +2871,15 @@ public class JClassPatcher {
         }
 
         // patch nature rune alching
-        LabelNode itemLabel = new LabelNode();
-        LabelNode originalLabel = new LabelNode();
-        LabelNode skipLabel = new LabelNode();
-
         insnNodeList = methodNode.instructions.iterator();
         while (insnNodeList.hasNext()) {
           AbstractInsnNode insnNode = insnNodeList.next();
 
           if (insnNode.getOpcode() == Opcodes.ICONST_4) {
+            LabelNode itemLabel = new LabelNode();
+            LabelNode originalLabel = new LabelNode();
+            LabelNode skipLabel = new LabelNode();
+
             insnNode = insnNodeList.next().getPrevious().getPrevious().getPrevious();
 
             methodNode.instructions.insertBefore(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -101,6 +101,7 @@ public class Settings {
   public static HashMap<String, Boolean> INVENTORY_FULL_ALERT = new HashMap<String, Boolean>();
   public static HashMap<String, Integer> NAME_PATCH_TYPE = new HashMap<String, Integer>();
   public static HashMap<String, Integer> COMMAND_PATCH_LEGACY = new HashMap<String, Integer>();
+  public static HashMap<String, Boolean> DISABLE_NAT_RUNE_ALCH = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMMAND_PATCH_QUEST = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> COMMAND_PATCH_EDIBLE_RARES =
       new HashMap<String, Boolean>();
@@ -349,6 +350,7 @@ public class Settings {
   public static boolean VIEW_DISTANCE_BOOL = false;
   public static boolean FOV_BOOL = false;
   public static boolean USE_JAGEX_FONTS_BOOL = false;
+  public static boolean PROTECT_NAT_RUNE_ALCH_BOOL = false;
 
   // determines which preset to load, or your custom settings :-)
   public static String currentProfile = "custom";
@@ -606,6 +608,16 @@ public class Settings {
     NAME_PATCH_TYPE.put("all", 3);
     NAME_PATCH_TYPE.put(
         "custom", getPropInt(props, "name_patch_type", NAME_PATCH_TYPE.get("default")));
+
+    DISABLE_NAT_RUNE_ALCH.put("vanilla", false);
+    DISABLE_NAT_RUNE_ALCH.put("vanilla_resizable", false);
+    DISABLE_NAT_RUNE_ALCH.put("lite", true);
+    DISABLE_NAT_RUNE_ALCH.put("default", true);
+    DISABLE_NAT_RUNE_ALCH.put("heavy", true);
+    DISABLE_NAT_RUNE_ALCH.put("all", true);
+    DISABLE_NAT_RUNE_ALCH.put(
+            "custom", getPropBoolean(props, "disable_nat_rune_alch", DISABLE_NAT_RUNE_ALCH.get("default")));
+
 
     /**
      * LEGACY, NOT USED EXCEPT TO MIGRATE SETTINGS Defines to what extent fix the item commands
@@ -2761,6 +2773,7 @@ public class Settings {
       props.setProperty("fatigue_alert", Boolean.toString(FATIGUE_ALERT.get(preset)));
       props.setProperty("inventory_full_alert", Boolean.toString(INVENTORY_FULL_ALERT.get(preset)));
       props.setProperty("name_patch_type", Integer.toString(NAME_PATCH_TYPE.get(preset)));
+      props.setProperty("disable_nat_rune_alch", Boolean.toString(DISABLE_NAT_RUNE_ALCH.get(preset)));
       props.setProperty("command_patch_quest", Boolean.toString(COMMAND_PATCH_QUEST.get(preset)));
       props.setProperty(
           "command_patch_edible_rares", Boolean.toString(COMMAND_PATCH_EDIBLE_RARES.get(preset)));
@@ -4206,6 +4219,7 @@ public class Settings {
     CAMERA_ROTATABLE_BOOL = CAMERA_ROTATABLE.get(currentProfile);
     CAMERA_MOVABLE_BOOL = CAMERA_MOVABLE.get(currentProfile);
     USE_JAGEX_FONTS_BOOL = USE_JAGEX_FONTS.get(currentProfile);
+    PROTECT_NAT_RUNE_ALCH_BOOL = DISABLE_NAT_RUNE_ALCH.get(currentProfile);
   }
 
   public static void outputInjectedVariables() {

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -616,8 +616,8 @@ public class Settings {
     DISABLE_NAT_RUNE_ALCH.put("heavy", true);
     DISABLE_NAT_RUNE_ALCH.put("all", true);
     DISABLE_NAT_RUNE_ALCH.put(
-            "custom", getPropBoolean(props, "disable_nat_rune_alch", DISABLE_NAT_RUNE_ALCH.get("default")));
-
+        "custom",
+        getPropBoolean(props, "disable_nat_rune_alch", DISABLE_NAT_RUNE_ALCH.get("default")));
 
     /**
      * LEGACY, NOT USED EXCEPT TO MIGRATE SETTINGS Defines to what extent fix the item commands
@@ -2773,7 +2773,8 @@ public class Settings {
       props.setProperty("fatigue_alert", Boolean.toString(FATIGUE_ALERT.get(preset)));
       props.setProperty("inventory_full_alert", Boolean.toString(INVENTORY_FULL_ALERT.get(preset)));
       props.setProperty("name_patch_type", Integer.toString(NAME_PATCH_TYPE.get(preset)));
-      props.setProperty("disable_nat_rune_alch", Boolean.toString(DISABLE_NAT_RUNE_ALCH.get(preset)));
+      props.setProperty(
+          "disable_nat_rune_alch", Boolean.toString(DISABLE_NAT_RUNE_ALCH.get(preset)));
       props.setProperty("command_patch_quest", Boolean.toString(COMMAND_PATCH_QUEST.get(preset)));
       props.setProperty(
           "command_patch_edible_rares", Boolean.toString(COMMAND_PATCH_EDIBLE_RARES.get(preset)));


### PR DESCRIPTION
New checkbox within the item patching panel that disables the ability to cast alchemy spells on nature runes