### PR TITLE
Scale fixes

### DIFF
--- a/src/Client/Launcher.java
+++ b/src/Client/Launcher.java
@@ -436,10 +436,13 @@ public class Launcher extends JFrame implements Runnable {
   }
 
   public static void main(String[] args) {
-    // Do this before anything else runs to override OS-level
-    // dpi settings, since we have in-client scaling now
-    System.setProperty("sun.java2d.uiScale.enabled", "false");
-    System.setProperty("sun.java2d.uiScale", "1");
+    // Do this before anything else runs to override OS-level dpi settings,
+    // since we have in-client scaling now (not applicable to macOS, which
+    // implements OS-scaling in a different fashion)
+    if (!Util.isMacOS()) {
+      System.setProperty("sun.java2d.uiScale.enabled", "false");
+      System.setProperty("sun.java2d.uiScale", "1");
+    }
 
     numCores = Runtime.getRuntime().availableProcessors();
 

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -279,6 +279,8 @@ public class ScaledWindow extends JFrame
 
       viewportWidth = gameImage.getWidth();
       viewportHeight = gameImage.getHeight();
+
+      validateAppletSize();
     }
 
     if (Renderer.renderingScalar == 1.0f) {
@@ -405,6 +407,21 @@ public class ScaledWindow extends JFrame
     }
   }
 
+  /** Resizes the mudclient if its dimensions don't align with the current frame size */
+  private void validateAppletSize() {
+    Applet mudclient = Game.getInstance().getApplet();
+
+    if (mudclient == null) return;
+
+    int newWidth = Math.round(scaledViewport.getWidth() / Renderer.renderingScalar);
+    int newHeight = Math.round(scaledViewport.getHeight() / Renderer.renderingScalar);
+
+    if (mudclient.getWidth() != newWidth || mudclient.getHeight() != newHeight) {
+      mudclient.setSize(newWidth, newHeight);
+      Renderer.resize(newWidth, newHeight);
+    }
+  }
+
   public void disposeJFrame() {
     dispose();
   }
@@ -469,6 +486,8 @@ public class ScaledWindow extends JFrame
   @Override
   public void componentResized(ComponentEvent e) {
     resizeApplet();
+    frameWidth = e.getComponent().getWidth();
+    frameHeight = e.getComponent().getHeight();
   }
 
   @Override

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -40,6 +40,7 @@ public class ScaledWindow extends JFrame
   // Singleton
   private static ScaledWindow instance = null;
   private static boolean initialRender = true;
+  private static boolean isMacOS = false;
   private static boolean shouldRealign = false;
   private int frameWidth = 0;
   private int frameHeight = 0;
@@ -104,7 +105,9 @@ public class ScaledWindow extends JFrame
     setDropTarget(ReplayQueue.dropReplays);
 
     // Enable macOS fullscreen button, if possible
-    if (Util.isMacOS()) {
+    isMacOS = Util.isMacOS();
+
+    if (isMacOS) {
       try {
         Class util = Class.forName("com.apple.eawt.FullScreenUtilities");
         Class params[] = new Class[] {Window.class, Boolean.TYPE};
@@ -688,6 +691,12 @@ public class ScaledWindow extends JFrame
       // Nearest-neighbor scaling performs roughly 3x better when resized via drawImage(),
       // whereas interpolation scaling performs better using AffineTransformOp.
       if (isIntegerScaling()) {
+        // Workaround for direct drawImage warping which seems to only
+        // affect macOS on JDK 19
+        if (isMacOS && Settings.javaVersion >= 19) {
+          g.setClip(0, 0, newWidth, newHeight);
+        }
+
         g.drawImage(viewportImage, 0, 0, newWidth, newHeight, null);
       } else {
         if (interpolationBackground == null) {

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -155,6 +155,7 @@ public class ScaledWindow extends JFrame
   @Override
   public void setSize(int width, int height) {
     super.setSize(width, height);
+
     frameWidth = width;
     frameHeight = height;
   }
@@ -279,8 +280,6 @@ public class ScaledWindow extends JFrame
 
       viewportWidth = gameImage.getWidth();
       viewportHeight = gameImage.getHeight();
-
-      validateAppletSize();
     }
 
     if (Renderer.renderingScalar == 1.0f) {
@@ -407,8 +406,8 @@ public class ScaledWindow extends JFrame
     }
   }
 
-  /** Resizes the mudclient if its dimensions don't align with the current frame size */
-  private void validateAppletSize() {
+  /** Resizes the mudclient if its dimensions don't match the current frame size */
+  public void validateAppletSize() {
     Applet mudclient = Game.getInstance().getApplet();
 
     if (mudclient == null) return;
@@ -486,6 +485,7 @@ public class ScaledWindow extends JFrame
   @Override
   public void componentResized(ComponentEvent e) {
     resizeApplet();
+
     frameWidth = e.getComponent().getWidth();
     frameHeight = e.getComponent().getHeight();
   }

--- a/src/Client/ScaledWindow.java
+++ b/src/Client/ScaledWindow.java
@@ -510,14 +510,14 @@ public class ScaledWindow extends JFrame
   public void mouseEntered(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseEntered(e);
+    Client.handler_mouse.mouseEntered(mapMouseEvent(e));
   }
 
   @Override
   public void mouseExited(MouseEvent e) {
     if (Client.handler_mouse == null || Renderer.renderingScalar == 0.0f) return;
 
-    Client.handler_mouse.mouseExited(e);
+    Client.handler_mouse.mouseExited(mapMouseEvent(e));
   }
 
   @Override

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2326,6 +2326,24 @@ public class Settings {
       save("custom");
     }
 
+    if (INTEGER_SCALING_FACTOR.get("custom") < (int) Renderer.minScalar) {
+      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.minScalar);
+    } else if (INTEGER_SCALING_FACTOR.get("custom") > (int) Renderer.maxIntegerScalar) {
+      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.maxIntegerScalar);
+    }
+
+    if (BILINEAR_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
+      BILINEAR_SCALING_FACTOR.put("custom", Renderer.minScalar);
+    } else if (BILINEAR_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
+      BILINEAR_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
+    }
+
+    if (BICUBIC_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
+      BICUBIC_SCALING_FACTOR.put("custom", Renderer.minScalar);
+    } else if (BICUBIC_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
+      BICUBIC_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
+    }
+
     if (WORLD.get("custom") < 0) {
       WORLD.put("custom", 0);
       save("custom");

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -27,6 +27,7 @@ import Client.Launcher;
 import Client.Logger;
 import Client.NotificationsHandler;
 import Client.NotificationsHandler.NotifType;
+import Client.ScaledWindow;
 import Client.Settings;
 import Client.Speedrun;
 import Client.TwitchIRC;
@@ -1283,6 +1284,10 @@ public class Client {
     }
 
     resetFatigueXPDrops(false);
+
+    // Re-validate the current scaling upon logging in, in case something
+    // went wrong during the initial window creation and resizing.
+    ScaledWindow.getInstance().validateAppletSize();
   }
 
   public static void disconnect_hook() {


### PR DESCRIPTION
This PR contains various adjustments to the scaling code:

* Two small fixes targeting macOS:
    * The logic I had previously added which forcibly disables java's own UI scaling seems to have a strange effect on macOS, particularly on Java 11+, where all `Graphics` images become blurry. To work around this, I now perform an OS check before setting the property.
    * Specific to macOS and JDK 19, integer scaling via `drawImage` seems to forcibly override the provided width and height values, when the final image is larger than the displayable area. I discovered a fix to prevent this behavior, by setting the `clip` property on the `Graphics` object to the expected bounds.
* Corrected two mouseHandler methods where I had missed scale-mapping their values in the original implementation
* Sanitizing scalar values from config.ini on load
* Added mudclient size validation on character login as a secondary safety check in case something went wrong during initial window creation