### PR TITLE
Sort player names in overlay, option to hide own name, show pid in debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ keyword stored.
 
 *::toggleplayerinfo* - Toggle Player info
 
+*::toggleowninfo* - Toggle own player info
+
 *::togglehitbox* - Toggle hitboxes for NPC info
 
 *::togglexpdrops* - Toggle XP drops

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -243,6 +243,7 @@ public class ConfigWindow {
   private JCheckBox overlayPanelRetroFpsCheckbox;
   private JCheckBox overlayPanelItemNamesCheckbox;
   private JCheckBox overlayPanelPlayerNamesCheckbox;
+  private JCheckBox overlayPanelOwnNameCheckbox;
   private JCheckBox overlayPanelFriendNamesCheckbox;
   private JCheckBox overlayPanelNPCNamesCheckbox;
   private JCheckBox overlayPanelIDsCheckbox;
@@ -1767,6 +1768,9 @@ public class ConfigWindow {
     overlayPanelPlayerNamesCheckbox.setToolTipText(
         "Shows players' display names over their character");
 
+    overlayPanelOwnNameCheckbox = addCheckbox("Show your own name over your head", overlayPanel);
+    overlayPanelOwnNameCheckbox.setToolTipText("Shows your own display name over your character");
+
     overlayPanelFriendNamesCheckbox =
         addCheckbox("Show nearby friend names over their heads", overlayPanel);
     overlayPanelFriendNamesCheckbox.setToolTipText(
@@ -2839,6 +2843,12 @@ public class ConfigWindow {
         KeyEvent.VK_P);
     addKeybindSet(
         keybindContainerPanel,
+        "Toggle own name overlay",
+        "toggle_own_name_overlay",
+        KeyModifier.ALT,
+        KeyEvent.VK_J);
+    addKeybindSet(
+        keybindContainerPanel,
         "Toggle friend name overlay",
         "toggle_friend_name_overlay",
         KeyModifier.CTRL,
@@ -3900,6 +3910,8 @@ public class ConfigWindow {
         Settings.SHOW_ITEM_GROUND_OVERLAY.get(Settings.currentProfile));
     overlayPanelPlayerNamesCheckbox.setSelected(
         Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile));
+    overlayPanelOwnNameCheckbox.setSelected(
+        Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile));
     overlayPanelFriendNamesCheckbox.setSelected(
         Settings.SHOW_FRIEND_NAME_OVERLAY.get(Settings.currentProfile));
     overlayPanelNPCNamesCheckbox.setSelected(
@@ -4330,6 +4342,8 @@ public class ConfigWindow {
         Settings.currentProfile, overlayPanelItemNamesCheckbox.isSelected());
     Settings.SHOW_PLAYER_NAME_OVERLAY.put(
         Settings.currentProfile, overlayPanelPlayerNamesCheckbox.isSelected());
+    Settings.SHOW_OWN_NAME_OVERLAY.put(
+        Settings.currentProfile, overlayPanelOwnNameCheckbox.isSelected());
     Settings.SHOW_FRIEND_NAME_OVERLAY.put(
         Settings.currentProfile, overlayPanelFriendNamesCheckbox.isSelected());
     Settings.SHOW_NPC_NAME_OVERLAY.put(

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1768,8 +1768,8 @@ public class ConfigWindow {
     overlayPanelPlayerNamesCheckbox.setToolTipText(
         "Shows players' display names over their character");
 
-    overlayPanelOwnNameCheckbox = addCheckbox("Show your own name over your head", overlayPanel);
-    overlayPanelOwnNameCheckbox.setToolTipText("Shows your own display name over your character");
+    overlayPanelOwnNameCheckbox = addCheckbox("Show your own name over your head when player names are enabled", overlayPanel);
+    overlayPanelOwnNameCheckbox.setToolTipText("Shows your own display name over your character when player names are shown");
 
     overlayPanelFriendNamesCheckbox =
         addCheckbox("Show nearby friend names over their heads", overlayPanel);

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1768,8 +1768,11 @@ public class ConfigWindow {
     overlayPanelPlayerNamesCheckbox.setToolTipText(
         "Shows players' display names over their character");
 
-    overlayPanelOwnNameCheckbox = addCheckbox("Show your own name over your head when player names are enabled", overlayPanel);
-    overlayPanelOwnNameCheckbox.setToolTipText("Shows your own display name over your character when player names are shown");
+    overlayPanelOwnNameCheckbox =
+        addCheckbox(
+            "Show your own name over your head when player names are enabled", overlayPanel);
+    overlayPanelOwnNameCheckbox.setToolTipText(
+        "Shows your own display name over your character when player names are shown");
 
     overlayPanelFriendNamesCheckbox =
         addCheckbox("Show nearby friend names over their heads", overlayPanel);

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -223,6 +223,7 @@ public class Settings {
       new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_ITEM_GROUND_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_PLAYER_NAME_OVERLAY = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SHOW_OWN_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_FRIEND_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_NPC_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> EXTEND_IDS_OVERLAY = new HashMap<String, Boolean>();
@@ -1628,6 +1629,15 @@ public class Settings {
         "custom",
         getPropBoolean(props, "show_playerinfo", SHOW_PLAYER_NAME_OVERLAY.get("default")));
 
+    SHOW_OWN_NAME_OVERLAY.put("vanilla", false);
+    SHOW_OWN_NAME_OVERLAY.put("vanilla_resizable", false);
+    SHOW_OWN_NAME_OVERLAY.put("lite", false);
+    SHOW_OWN_NAME_OVERLAY.put("default", false);
+    SHOW_OWN_NAME_OVERLAY.put("heavy", false);
+    SHOW_OWN_NAME_OVERLAY.put("all", true);
+    SHOW_OWN_NAME_OVERLAY.put(
+        "custom", getPropBoolean(props, "show_owninfo", SHOW_OWN_NAME_OVERLAY.get("default")));
+
     SHOW_FRIEND_NAME_OVERLAY.put("vanilla", false);
     SHOW_FRIEND_NAME_OVERLAY.put("vanilla_resizable", false);
     SHOW_FRIEND_NAME_OVERLAY.put("lite", false);
@@ -2925,6 +2935,7 @@ public class Settings {
           Boolean.toString(TOGGLE_XP_BAR_ON_STATS_BUTTON.get(preset)));
       props.setProperty("show_iteminfo", Boolean.toString(SHOW_ITEM_GROUND_OVERLAY.get(preset)));
       props.setProperty("show_playerinfo", Boolean.toString(SHOW_PLAYER_NAME_OVERLAY.get(preset)));
+      props.setProperty("show_owninfo", Boolean.toString(SHOW_OWN_NAME_OVERLAY.get(preset)));
       props.setProperty("show_friendinfo", Boolean.toString(SHOW_FRIEND_NAME_OVERLAY.get(preset)));
       props.setProperty("show_npcinfo", Boolean.toString(SHOW_NPC_NAME_OVERLAY.get(preset)));
       props.setProperty("extend_idsinfo", Boolean.toString(EXTEND_IDS_OVERLAY.get(preset)));
@@ -3480,6 +3491,18 @@ public class Settings {
     save();
   }
 
+  public static void toggleShowOwnNameOverlay() {
+    SHOW_OWN_NAME_OVERLAY.put(currentProfile, !SHOW_OWN_NAME_OVERLAY.get(currentProfile));
+
+    if (SHOW_OWN_NAME_OVERLAY.get(currentProfile)) {
+      Client.displayMessage("@cya@Your own name is now shown", Client.CHAT_NONE);
+    } else {
+      Client.displayMessage("@cya@Your own name is now hidden", Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
   public static void toggleExtendIdsOverlay() {
     EXTEND_IDS_OVERLAY.put(currentProfile, !EXTEND_IDS_OVERLAY.get(currentProfile));
 
@@ -3992,6 +4015,9 @@ public class Settings {
         return true;
       case "toggle_player_name_overlay":
         Settings.toggleShowPlayerNameOverlay();
+        return true;
+      case "toggle_own_name_overlay":
+        Settings.toggleShowOwnNameOverlay();
         return true;
       case "toggle_bypass_attack":
         Settings.toggleAttackAlwaysLeftClick();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -3495,9 +3495,11 @@ public class Settings {
     SHOW_OWN_NAME_OVERLAY.put(currentProfile, !SHOW_OWN_NAME_OVERLAY.get(currentProfile));
 
     if (SHOW_OWN_NAME_OVERLAY.get(currentProfile)) {
-      Client.displayMessage("@cya@Your own name is now shown", Client.CHAT_NONE);
+      Client.displayMessage(
+          "@cya@Your own name is now shown when player names are enabled", Client.CHAT_NONE);
     } else {
-      Client.displayMessage("@cya@Your own name is now hidden", Client.CHAT_NONE);
+      Client.displayMessage(
+          "@cya@Your own name is no longer shown when player names are enabled", Client.CHAT_NONE);
     }
 
     save();

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -221,6 +221,7 @@ public class Client {
 
   public static Object player_object;
   public static String player_name = "";
+  public static int player_id = -1;
   public static String xpUsername = "";
   public static boolean knowWhoIAm = false;
   public static int player_posX = -1;
@@ -1016,6 +1017,7 @@ public class Client {
 
     if (state == STATE_GAME) {
       Client.getPlayerName();
+      player_id = Client.getPlayerId();
       Client.adaptLoginInfo();
     }
 
@@ -1211,6 +1213,7 @@ public class Client {
     Replay.closeReplayRecording();
     adaptStrings();
     player_name = "";
+    player_id = -1;
   }
 
   public static void init_game() {
@@ -1290,6 +1293,7 @@ public class Client {
     Replay.closeReplayRecording();
     Speedrun.saveAndQuitSpeedrun();
     player_name = "";
+    player_id = -1;
     knowWhoIAm = false;
     Client.tipOfDay = -1;
   }
@@ -1583,6 +1587,17 @@ public class Client {
     }
   }
 
+  /** Stores the user's pid in {@link #player_id}. */
+  public static int getPlayerId() {
+    int pid = -1;
+    try {
+      pid = (int) Reflection.characterId.get(player_object);
+      return pid;
+    } catch (Exception e) {
+    }
+    return pid;
+  }
+
   public static int getPlayerWaypointX() {
     int x = 0;
     try {
@@ -1703,6 +1718,9 @@ public class Client {
           break;
         case "toggleplayerinfo":
           Settings.toggleShowPlayerNameOverlay();
+          break;
+        case "toggleowninfo":
+          Settings.toggleShowOwnNameOverlay();
           break;
         case "togglefriendinfo":
           Settings.toggleShowFriendNameOverlay();

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -37,6 +37,7 @@ public class Reflection {
   public static Constructor buffer = null;
 
   public static Field characterName = null;
+  public static Field characterId = null;
   public static Field characterDisplayName = null;
   public static Field characterX = null;
   public static Field characterY = null;
@@ -692,6 +693,7 @@ public class Reflection {
       // Character
       c = classLoader.loadClass("ta");
       characterName = c.getDeclaredField("C");
+      characterId = c.getDeclaredField("b");
       characterDisplayName = c.getDeclaredField("c");
       characterX = c.getDeclaredField("i");
       characterY = c.getDeclaredField("K");
@@ -703,6 +705,7 @@ public class Reflection {
       attackingPlayerIdx = c.getDeclaredField("z");
       attackingNpcIdx = c.getDeclaredField("h");
       if (characterName != null) characterName.setAccessible(true);
+      if (characterId != null) characterId.setAccessible(true);
       if (characterDisplayName != null) characterDisplayName.setAccessible(true);
       if (characterX != null) characterX.setAccessible(true);
       if (characterY != null) characterY.setAccessible(true);

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -441,12 +441,18 @@ public class Renderer {
         List<Rectangle> player_hitbox = new ArrayList<>();
         List<Point> entity_text_loc = new ArrayList<>();
 
+        Client.npc_list.sort(
+            Comparator.comparing(npc -> npc.name, Comparator.nullsLast(Comparator.naturalOrder())));
+
         for (Iterator<NPC> iterator = Client.npc_list.iterator(); iterator.hasNext(); ) {
           NPC npc = iterator.next(); // TODO: Remove unnecessary allocations
           Color color = color_low;
 
           boolean showName = false;
-          if (npc.type == NPC.TYPE_PLAYER) {
+          if (npc.type == NPC.TYPE_PLAYER 
+              && npc.name != null
+              && Client.player_name != null
+              && !npc.name.equals(Client.player_name)) {
             color = color_fatigue;
 
             if (Client.isFriend(npc.name)) {

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -449,10 +449,7 @@ public class Renderer {
           Color color = color_low;
 
           boolean showName = false;
-          if (npc.type == NPC.TYPE_PLAYER 
-              && npc.name != null
-              && Client.player_name != null
-              && !npc.name.equals(Client.player_name)) {
+          if (npc.type == NPC.TYPE_PLAYER) {
             color = color_fatigue;
 
             if (Client.isFriend(npc.name)) {
@@ -461,7 +458,14 @@ public class Renderer {
                   || Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile))) {
                 showName = true;
               }
-            } else if (Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile)) {
+            } else if (Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile)
+                && npc.name != null
+                && Client.player_name != null
+                && !npc.name.equals(Client.player_name)) {
+              showName = true;
+            } else if (Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile)
+                && npc.name != null
+                && npc.name.equals(Client.player_name)) {
               showName = true;
             }
           } else if (npc.type == NPC.TYPE_MOB
@@ -1317,7 +1321,8 @@ public class Renderer {
 
         x = 380;
         y = 32;
-        drawShadowText(g2, Client.player_name, x, y, color_text, false);
+        drawShadowText(
+            g2, Client.player_name + " (pid: " + Client.player_id + ")", x, y, color_text, false);
         y += 16;
         drawShadowText(g2, "Player Count: " + playerCount, x, y, color_text, false);
         y += 16;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -448,7 +448,6 @@ public class Renderer {
         } catch (Exception e) {
           // Sometimes Java helpfully complains that the sorting method violates its general
           // contract.
-          e.printStackTrace();
         }
 
         for (Iterator<NPC> iterator = Client.npc_list.iterator(); iterator.hasNext(); ) {
@@ -539,7 +538,6 @@ public class Renderer {
           } catch (Exception e) {
             // Sometimes Java helpfully complains that the sorting method violates its general
             // contract.
-            e.printStackTrace();
           }
         }
 

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -441,8 +441,15 @@ public class Renderer {
         List<Rectangle> player_hitbox = new ArrayList<>();
         List<Point> entity_text_loc = new ArrayList<>();
 
-        Client.npc_list.sort(
-            Comparator.comparing(npc -> npc.name, Comparator.nullsLast(Comparator.naturalOrder())));
+        try {
+          Client.npc_list.sort(
+              Comparator.comparing(
+                  npc -> npc.name, Comparator.nullsLast(Comparator.naturalOrder())));
+        } catch (Exception e) {
+          // Sometimes Java helpfully complains that the sorting method violates its general
+          // contract.
+          e.printStackTrace();
+        }
 
         for (Iterator<NPC> iterator = Client.npc_list.iterator(); iterator.hasNext(); ) {
           NPC npc = iterator.next(); // TODO: Remove unnecessary allocations

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -464,15 +464,13 @@ public class Renderer {
                   || Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile))) {
                 showName = true;
               }
-            } else if (Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile)
-                && npc.name != null
-                && Client.player_name != null
-                && !npc.name.equals(Client.player_name)) {
-              showName = true;
-            } else if (Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile)
-                && npc.name != null
-                && npc.name.equals(Client.player_name)) {
-              showName = true;
+            } else if (Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile)) {
+              boolean isOwnName = npc.name != null && npc.name.equals(Client.player_name);
+              if (isOwnName) {
+                showName = Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile);
+              } else {
+                showName = true;
+              }
             }
           } else if (npc.type == NPC.TYPE_MOB
               && Settings.SHOW_NPC_NAME_OVERLAY.get(Settings.currentProfile)) {


### PR DESCRIPTION
Modified the player name overlay behavior to:

1. No longer display your own name
2. Maintain a fixed sort-order of names to prevent the "dancing" that occurs when multiple players occupy the same tile