### PR TITLE
Option to disable skill pinning from stats menu

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -359,7 +359,6 @@ public class Settings {
   public static boolean PROTECT_NAT_RUNE_ALCH_BOOL = false;
   public static boolean LOAD_CHAT_HISTORY_BOOL = false;
 
-
   // determines which preset to load, or your custom settings :-)
   public static String currentProfile = "custom";
 
@@ -2540,6 +2539,7 @@ public class Settings {
       XPBar.pinnedSkill = getPropInt(props, "pinnedSkill", -1);
       XPBar.showActionCount = getPropBoolean(props, "showActionCount", true);
       XPBar.showTimeCount = getPropBoolean(props, "showTimeCount", true);
+      XPBar.skillClickPinning = getPropBoolean(props, "skillClickPinning", true);
 
       Logger.Info("Loaded settings");
       return props;
@@ -3152,6 +3152,7 @@ public class Settings {
       props.setProperty("pinnedSkill", String.format("%d", XPBar.pinnedSkill));
       props.setProperty("showActionCount", Boolean.toString(XPBar.showActionCount));
       props.setProperty("showTimeCount", Boolean.toString(XPBar.showTimeCount));
+      props.setProperty("skillClickPinning", Boolean.toString(XPBar.skillClickPinning));
 
       // World Map
       props.setProperty("worldmap_show_icons", Boolean.toString(WorldMapWindow.showIcons));
@@ -3423,6 +3424,11 @@ public class Settings {
     if (SHOW_XP_BAR.get(currentProfile))
       Client.displayMessage("@cya@XP Bar is now shown", Client.CHAT_NONE);
     else Client.displayMessage("@cya@XP Bar is now hidden", Client.CHAT_NONE);
+    save();
+  }
+
+  public static void toggleSkillClickPinning() {
+    XPBar.skillClickPinning = !XPBar.skillClickPinning;
     save();
   }
 

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -1172,6 +1172,7 @@ public class Renderer {
       // Handle setting XP Bar stat from STATS menu
       if (Client.show_menu == Client.MENU_STATS_QUESTS
           && Client.show_stats_or_quests == Client.MENU_STATS
+          && XPBar.skillClickPinning
           && bufferedMouseClick.isMouseClicked()) {
         int xOffset = width - 199;
         int yOffset = 85;

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -31,6 +31,7 @@ public class XPBar {
   public static boolean showActionCount = true;
   public static boolean showTimeCount = true;
   private static float alpha;
+  public static boolean skillClickPinning = true;
   public static boolean pinnedBar = false;
   public static int pinnedSkill = -1;
   public static int drawGoalInputState = 0;
@@ -39,7 +40,7 @@ public class XPBar {
   public static final String excludeUsername = "excludemefromxpbartracking";
 
   public static Dimension bounds = new Dimension(110, 16);
-  public static Dimension menuBounds = new Dimension(110, 80);
+  public static Dimension menuBounds = new Dimension(110, 92);
   public static int xp_bar_x;
   // Don't need to set this more than once; we are always positioning the xp_bar to be vertically
   // center aligned with
@@ -280,6 +281,24 @@ public class XPBar {
         g, showTimeCount ? "Hide times" : "Show times", x, y, textColour, false);
 
     // Option 5
+    if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
+      textColour = Renderer.color_yellow;
+      if (bufferedMouseClick.isMouseClicked()) {
+        Settings.toggleSkillClickPinning();
+      }
+    } else {
+      textColour = Renderer.color_text;
+    }
+    y += 12;
+    Renderer.drawShadowText(
+        g,
+        skillClickPinning ? "Skill clicking: on" : "Skill clicking: off",
+        x,
+        y,
+        textColour,
+        false);
+
+    // Option 6
     if (MouseHandler.y > y + offset && MouseHandler.y < y + textHeight) {
       textColour = Renderer.color_yellow;
       if (bufferedMouseClick.isMouseClicked()) {


### PR DESCRIPTION
Adds a new option to the XP Bar right-click menu which allows the user to disable the pinning behavior that occurs when clicking on a skill from the stats menu (on by default)

Also has the benefit of informing new users that they may click on a skill to pin it

![2023_04_01_11_25_AM](https://user-images.githubusercontent.com/16803725/229303106-8a189eba-6bb6-41d6-955c-248c82544e83.png)
