### PR TITLE
Rework xp bar menu

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -359,7 +359,6 @@ public class Settings {
   public static boolean PROTECT_NAT_RUNE_ALCH_BOOL = false;
   public static boolean LOAD_CHAT_HISTORY_BOOL = false;
 
-
   // determines which preset to load, or your custom settings :-)
   public static String currentProfile = "custom";
 

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -89,7 +89,8 @@ public class XPBar {
   public XPBar() {
     current_skill = -1;
     menuBounds.height =
-        (menuItemSpacing * 1.5) + (menuItems.size() * (menuItemSpacing + menuItemHeight));
+        (int) Math.ceil(menuItemSpacing * 1.5)
+            + (menuItems.size() * (menuItemSpacing + menuItemHeight));
   }
 
   void setSkill(int skill) {

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -57,41 +57,39 @@ public class XPBar {
 
   private long m_timer;
 
-  private ArrayList<MenuItem> menuItems = new ArrayList<MenuItem>() {{
-    add(new MenuItem(
-      () -> "Reset XP period",
-      () -> resetXPGainStart()
-    ));
-    add(new MenuItem(
-      () -> hasGoalForSkill(current_skill) ? "Clear Goal" : "Set Goal",
-      () -> setXPGoal()
-    ));
-    add(new MenuItem(
-      () -> pinnedSkill >= 0 ? "Use recent skill" : "Keep this skill",
-      () -> pinSkill()
-    ));
-    add(new MenuItem(
-      () -> showActionCount ? "Hide actions" : "Show actions",
-      () -> Settings.toggleActionCount()
-    ));
-    add(new MenuItem(
-      () -> showTimeCount ? "Hide times" : "Show times",
-      () -> Settings.toggleTimeCount()
-    ));
-    add(new MenuItem(
-      () -> pinnedBar ? "Unpin bar" : "Pin bar",
-      () -> Settings.toggleXPBarPin()
-    ));
-  }};
+  private ArrayList<MenuItem> menuItems =
+      new ArrayList<MenuItem>() {
+        {
+          add(new MenuItem(() -> "Reset XP period", () -> resetXPGainStart()));
+          add(
+              new MenuItem(
+                  () -> hasGoalForSkill(current_skill) ? "Clear Goal" : "Set Goal",
+                  () -> setXPGoal()));
+          add(
+              new MenuItem(
+                  () -> pinnedSkill >= 0 ? "Use recent skill" : "Keep this skill",
+                  () -> pinSkill()));
+          add(
+              new MenuItem(
+                  () -> showActionCount ? "Hide actions" : "Show actions",
+                  () -> Settings.toggleActionCount()));
+          add(
+              new MenuItem(
+                  () -> showTimeCount ? "Hide times" : "Show times",
+                  () -> Settings.toggleTimeCount()));
+          add(
+              new MenuItem(
+                  () -> pinnedBar ? "Unpin bar" : "Pin bar", () -> Settings.toggleXPBarPin()));
+        }
+      };
 
   private int menuItemSpacing = 6;
   private int menuItemHeight = 12;
 
   public XPBar() {
     current_skill = -1;
-    menuBounds.height = (menuItemSpacing * 1.5) + (
-      menuItems.size() * (menuItemSpacing + menuItemHeight)
-    );
+    menuBounds.height =
+        (menuItemSpacing * 1.5) + (menuItems.size() * (menuItemSpacing + menuItemHeight));
   }
 
   void setSkill(int skill) {
@@ -252,7 +250,8 @@ public class XPBar {
     // Draw the menu items
     for (MenuItem menuItem : menuItems) {
       y = drawMenuItem(g, x, y, bufferedMouseClick.isMouseClicked(), menuItem);
-    };
+    }
+    ;
   }
 
   private int drawMenuItem(Graphics2D g, int x, int y, boolean clicking, MenuItem menuItem) {

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -84,7 +84,7 @@ public class XPBar {
     ));
   }};
 
-  private int menuItemSpacing = 4;
+  private int menuItemSpacing = 6;
   private int menuItemHeight = 12;
 
   public XPBar() {


### PR DESCRIPTION
Slightly increases the spacing between items on the right-click menu of the XP bar.

As a (major) side-effect, also reworks the way in which the right-click menu of the XP bar is built to make it easier to add new items or customise existing ones.

This is my first commit to the project (and I don't write in Java very often) so please let me know if there's any functional or stylistic improvements to be made.

Also worth noting that this conflicts with https://github.com/RSCPlus/rscplus/pull/147

Before:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/4449351/229314378-942d8a8e-786e-4de6-a23e-aef18a29a907.png">

After:
<img width="220" alt="image" src="https://user-images.githubusercontent.com/4449351/229314511-bffaae19-b96c-483b-8cef-7f42a421bcbe.png">
