### PR TITLE
Highlight attackable player names in wilderness

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -246,6 +246,10 @@ public class ConfigWindow {
   private JCheckBox overlayPanelRetroFpsCheckbox;
   private JCheckBox overlayPanelItemNamesCheckbox;
   private JCheckBox overlayPanelPlayerNamesCheckbox;
+  private JCheckBox overlayPanelPvpNamesCheckbox;
+  private JPanel overlayPanelPvpNamesColourSubpanel;
+  private Color pvpNamesColour =
+      Util.intToColor(Settings.PVP_NAMES_COLOUR.get(Settings.currentProfile));
   private JCheckBox overlayPanelOwnNameCheckbox;
   private JCheckBox overlayPanelFriendNamesCheckbox;
   private JCheckBox overlayPanelNPCNamesCheckbox;
@@ -1811,6 +1815,51 @@ public class ConfigWindow {
         addCheckbox("Show player names over their heads", overlayPanel);
     overlayPanelPlayerNamesCheckbox.setToolTipText(
         "Shows players' display names over their character");
+
+    // pvp names sub-panel
+    JPanel overlayPanelPvpNamesPanel = new JPanel();
+    overlayPanel.add(overlayPanelPvpNamesPanel);
+    overlayPanelPvpNamesPanel.setLayout(new BoxLayout(overlayPanelPvpNamesPanel, BoxLayout.X_AXIS));
+    overlayPanelPvpNamesPanel.setPreferredSize(new Dimension(0, 26));
+    overlayPanelPvpNamesPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+    overlayPanelPvpNamesCheckbox =
+        addCheckbox(
+            "Show attackable players' names in a separate colour", overlayPanelPvpNamesPanel);
+    overlayPanelPvpNamesCheckbox.setToolTipText(
+        "Changes the color of players' names when they are within attacking range in the wilderness");
+
+    overlayPanelPvpNamesColourSubpanel = new JPanel();
+    overlayPanelPvpNamesPanel.add(overlayPanelPvpNamesColourSubpanel);
+    overlayPanelPvpNamesColourSubpanel.setAlignmentY((float) 0.7f);
+    overlayPanelPvpNamesColourSubpanel.setMinimumSize(new Dimension(32, 20));
+    overlayPanelPvpNamesColourSubpanel.setPreferredSize(new Dimension(32, 20));
+    overlayPanelPvpNamesColourSubpanel.setMaximumSize(new Dimension(32, 20));
+    overlayPanelPvpNamesColourSubpanel.setBorder(BorderFactory.createLineBorder(Color.black));
+    overlayPanelPvpNamesColourSubpanel.setBackground(pvpNamesColour);
+
+    JPanel overlayPanelPvpNamesSpacingPanel = new JPanel();
+    overlayPanelPvpNamesPanel.add(overlayPanelPvpNamesSpacingPanel);
+    overlayPanelPvpNamesSpacingPanel.setMinimumSize(new Dimension(4, 20));
+    overlayPanelPvpNamesSpacingPanel.setPreferredSize(new Dimension(4, 20));
+    overlayPanelPvpNamesSpacingPanel.setMaximumSize(new Dimension(4, 20));
+
+    JButton pvpNamesColourChooserButton = new JButton("Choose colour");
+    pvpNamesColourChooserButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Color selected =
+                JColorChooser.showDialog(null, "Choose PVP display name colour", pvpNamesColour);
+            if (null != selected) {
+              pvpNamesColour = selected;
+            }
+            overlayPanelPvpNamesColourSubpanel.setBackground(pvpNamesColour);
+          }
+        });
+    overlayPanelPvpNamesPanel.add(pvpNamesColourChooserButton);
+    pvpNamesColourChooserButton.setAlignmentY(0.7f);
+    ////////////
 
     overlayPanelOwnNameCheckbox =
         addCheckbox(
@@ -4041,6 +4090,9 @@ public class ConfigWindow {
         Settings.SHOW_ITEM_GROUND_OVERLAY.get(Settings.currentProfile));
     overlayPanelPlayerNamesCheckbox.setSelected(
         Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile));
+    overlayPanelPvpNamesCheckbox.setSelected(
+        Settings.SHOW_PVP_NAME_OVERLAY.get(Settings.currentProfile));
+    pvpNamesColour = Util.intToColor(Settings.PVP_NAMES_COLOUR.get(Settings.currentProfile));
     overlayPanelOwnNameCheckbox.setSelected(
         Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile));
     overlayPanelFriendNamesCheckbox.setSelected(
@@ -4484,6 +4536,9 @@ public class ConfigWindow {
         Settings.currentProfile, overlayPanelItemNamesCheckbox.isSelected());
     Settings.SHOW_PLAYER_NAME_OVERLAY.put(
         Settings.currentProfile, overlayPanelPlayerNamesCheckbox.isSelected());
+    Settings.SHOW_PVP_NAME_OVERLAY.put(
+        Settings.currentProfile, overlayPanelPvpNamesCheckbox.isSelected());
+    Settings.PVP_NAMES_COLOUR.put(Settings.currentProfile, Util.colorToInt(pvpNamesColour));
     Settings.SHOW_OWN_NAME_OVERLAY.put(
         Settings.currentProfile, overlayPanelOwnNameCheckbox.isSelected());
     Settings.SHOW_FRIEND_NAME_OVERLAY.put(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2000,10 +2000,24 @@ public class JClassPatcher {
         methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
         methodNode.instructions.insertBefore(
             insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "b", "I"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "Tb", "[Lta;"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 6));
+        methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "i", "I"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "Tb", "[Lta;"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 6));
+        methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "K", "I"));
         methodNode.instructions.insertBefore(
             insnNode,
             new MethodInsnNode(
-                Opcodes.INVOKESTATIC, "Game/Client", "drawNPC", "(IIIILjava/lang/String;IIII)V"));
+                Opcodes.INVOKESTATIC, "Game/Client", "drawNPC", "(IIIILjava/lang/String;IIIIII)V"));
       }
       if (methodNode.name.equals("b") && methodNode.desc.equals("(IIIIIIII)V")) {
         // Draw Player hook
@@ -2041,10 +2055,34 @@ public class JClassPatcher {
         methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
         methodNode.instructions.insertBefore(
             insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "b", "I"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "rg", "[Lta;"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 8));
+        methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "s", "I"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "rg", "[Lta;"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 8));
+        methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "i", "I"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ALOAD, 0));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "client", "rg", "[Lta;"));
+        methodNode.instructions.insertBefore(insnNode, new VarInsnNode(Opcodes.ILOAD, 8));
+        methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.AALOAD));
+        methodNode.instructions.insertBefore(
+            insnNode, new FieldInsnNode(Opcodes.GETFIELD, "ta", "K", "I"));
         methodNode.instructions.insertBefore(
             insnNode,
             new MethodInsnNode(
-                Opcodes.INVOKESTATIC, "Game/Client", "drawPlayer", "(IIIILjava/lang/String;III)V"));
+                Opcodes.INVOKESTATIC,
+                "Game/Client",
+                "drawPlayer",
+                "(IIIILjava/lang/String;IIIIII)V"));
       }
       if (methodNode.name.equals("b") && methodNode.desc.equals("(IIIIIII)V")) {
         // Draw Item hook
@@ -2381,6 +2419,9 @@ public class JClassPatcher {
               methodNode.instructions.insertBefore(
                   insnNode, new FieldInsnNode(Opcodes.GETSTATIC, "Game/Renderer", "width", "I"));
               methodNode.instructions.insert(
+                  insnNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "wild_level", "I"));
+              methodNode.instructions.insert(insnNode, new VarInsnNode(Opcodes.ILOAD, 3));
+              methodNode.instructions.insert(
                   insnNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "is_in_wild", "Z"));
               methodNode.instructions.insert(insnNode, new InsnNode(Opcodes.ICONST_1));
               methodNode.instructions.insert(insnNode, new InsnNode(Opcodes.ISUB));
@@ -2395,6 +2436,9 @@ public class JClassPatcher {
             methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
             methodNode.instructions.insertBefore(
                 insnNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "is_in_wild", "Z"));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_M1));
+            methodNode.instructions.insertBefore(
+                insnNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "wild_level", "I"));
           }
         }
 

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -230,6 +230,8 @@ public class Settings {
       new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_ITEM_GROUND_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_PLAYER_NAME_OVERLAY = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SHOW_PVP_NAME_OVERLAY = new HashMap<String, Boolean>();
+  public static HashMap<String, Integer> PVP_NAMES_COLOUR = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> SHOW_OWN_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_FRIEND_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_NPC_NAME_OVERLAY = new HashMap<String, Boolean>();
@@ -364,7 +366,6 @@ public class Settings {
   public static boolean LOAD_CHAT_HISTORY_BOOL = false;
   public static boolean HIGHLIGHT_ITEMS_MENU_BOOL = false;
   public static int ITEM_HIGHLIGHT_COLOUR_INT = 0xFFD700;
-
 
   // determines which preset to load, or your custom settings :-)
   public static String currentProfile = "custom";
@@ -1686,6 +1687,24 @@ public class Settings {
     SHOW_PLAYER_NAME_OVERLAY.put(
         "custom",
         getPropBoolean(props, "show_playerinfo", SHOW_PLAYER_NAME_OVERLAY.get("default")));
+
+    SHOW_PVP_NAME_OVERLAY.put("vanilla", false);
+    SHOW_PVP_NAME_OVERLAY.put("vanilla_resizable", false);
+    SHOW_PVP_NAME_OVERLAY.put("lite", false);
+    SHOW_PVP_NAME_OVERLAY.put("default", false);
+    SHOW_PVP_NAME_OVERLAY.put("heavy", false);
+    SHOW_PVP_NAME_OVERLAY.put("all", true);
+    SHOW_PVP_NAME_OVERLAY.put(
+        "custom", getPropBoolean(props, "show_pvpinfo", SHOW_PVP_NAME_OVERLAY.get("default")));
+
+    PVP_NAMES_COLOUR.put("vanilla", 0x990000); // red berry
+    PVP_NAMES_COLOUR.put("vanilla_resizable", 0x990000);
+    PVP_NAMES_COLOUR.put("lite", 0x990000);
+    PVP_NAMES_COLOUR.put("default", 0x990000);
+    PVP_NAMES_COLOUR.put("heavy", 0x990000);
+    PVP_NAMES_COLOUR.put("all", 0x990000);
+    PVP_NAMES_COLOUR.put(
+        "custom", getPropInt(props, "pvp_names_colour", PVP_NAMES_COLOUR.get("default")));
 
     SHOW_OWN_NAME_OVERLAY.put("vanilla", false);
     SHOW_OWN_NAME_OVERLAY.put("vanilla_resizable", false);
@@ -3041,6 +3060,8 @@ public class Settings {
           Boolean.toString(TOGGLE_XP_BAR_ON_STATS_BUTTON.get(preset)));
       props.setProperty("show_iteminfo", Boolean.toString(SHOW_ITEM_GROUND_OVERLAY.get(preset)));
       props.setProperty("show_playerinfo", Boolean.toString(SHOW_PLAYER_NAME_OVERLAY.get(preset)));
+      props.setProperty("show_pvpinfo", Boolean.toString(SHOW_PVP_NAME_OVERLAY.get(preset)));
+      props.setProperty("pvp_names_colour", Integer.toString(PVP_NAMES_COLOUR.get(preset)));
       props.setProperty("show_owninfo", Boolean.toString(SHOW_OWN_NAME_OVERLAY.get(preset)));
       props.setProperty("show_friendinfo", Boolean.toString(SHOW_FRIEND_NAME_OVERLAY.get(preset)));
       props.setProperty("show_npcinfo", Boolean.toString(SHOW_NPC_NAME_OVERLAY.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -179,6 +179,7 @@ public class Client {
   public static long poison_timer = 0L;
   public static boolean is_poisoned = false;
   public static boolean is_in_wild;
+  public static int wild_level;
   // fatigue units as sent by the server
   public static int fatigue;
   // fatigue in units
@@ -1599,6 +1600,16 @@ public class Client {
     } catch (Exception e) {
     }
     return pid;
+  }
+
+  public static int getPlayerLevel() {
+    int level = -1;
+    try {
+      level = (int) Reflection.characterLevel.get(player_object);
+      return level;
+    } catch (Exception e) {
+    }
+    return level;
   }
 
   public static int getPlayerWaypointX() {
@@ -3246,14 +3257,57 @@ public class Client {
       int currentHits,
       int maxHits,
       int id,
-      int id2) {
+      int id2,
+      int currentX,
+      int currentY) {
     // ILOAD 6 is index
-    npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_MOB, currentHits, maxHits, id, id2));
+    // npc level set to -1, would have to be calculated using the cmb lvl formula with values
+    // retrieved from the various GameData arrays
+    npc_list.add(
+        new NPC(
+            x,
+            y,
+            width,
+            height,
+            name,
+            NPC.TYPE_MOB,
+            currentHits,
+            maxHits,
+            id,
+            id2,
+            -1,
+            currentX,
+            currentY));
   }
 
   public static void drawPlayer(
-      int x, int y, int width, int height, String name, int currentHits, int maxHits, int id2) {
-    npc_list.add(new NPC(x, y, width, height, name, NPC.TYPE_PLAYER, currentHits, maxHits, 0, id2));
+      int x,
+      int y,
+      int width,
+      int height,
+      String name,
+      int currentHits,
+      int maxHits,
+      int id2,
+      int level,
+      int currentX,
+      int currentY) {
+    // ILOAD 8 is index
+    npc_list.add(
+        new NPC(
+            x,
+            y,
+            width,
+            height,
+            name,
+            NPC.TYPE_PLAYER,
+            currentHits,
+            maxHits,
+            0,
+            id2,
+            level,
+            currentX,
+            currentY));
   }
 
   public static void drawItem(int x, int y, int width, int height, int id) {

--- a/src/Game/NPC.java
+++ b/src/Game/NPC.java
@@ -33,6 +33,9 @@ class NPC {
   public int type;
   public int currentHits;
   public int maxHits;
+  public int level;
+  public int currentX;
+  public int currentY;
 
   public NPC(
       int x,
@@ -44,7 +47,10 @@ class NPC {
       int currentHits,
       int maxHits,
       int id,
-      int id2) {
+      int id2,
+      int level,
+      int currentX,
+      int currentY) {
     this.x = x;
     this.y = y;
     this.width = width;
@@ -55,5 +61,26 @@ class NPC {
     this.maxHits = maxHits;
     this.id = id;
     this.id2 = id2;
+    this.level = level;
+    this.currentX = currentX;
+    this.currentY = currentY;
+  }
+
+  public int getWildernessLevel() {
+    // division by 128 gives the localRegion values
+    int worldX = (currentX / 128) + Client.regionX;
+    int worldY = (currentY / 128) + Client.regionY;
+
+    int wild = 2203 - (worldY + (1776 - (944 * (worldY / 944))));
+
+    if (worldX + 2304 >= 2640) {
+      wild = -50;
+    }
+
+    if (wild > 0) {
+      return 1 + wild / 6;
+    }
+
+    return 0;
   }
 }

--- a/src/Game/Reflection.java
+++ b/src/Game/Reflection.java
@@ -39,6 +39,7 @@ public class Reflection {
   public static Field characterName = null;
   public static Field characterId = null;
   public static Field characterDisplayName = null;
+  public static Field characterLevel = null;
   public static Field characterX = null;
   public static Field characterY = null;
   public static Field characterDamageTaken = null;
@@ -695,6 +696,7 @@ public class Reflection {
       characterName = c.getDeclaredField("C");
       characterId = c.getDeclaredField("b");
       characterDisplayName = c.getDeclaredField("c");
+      characterLevel = c.getDeclaredField("s");
       characterX = c.getDeclaredField("i");
       characterY = c.getDeclaredField("K");
       characterDamageTaken = c.getDeclaredField("u");
@@ -707,6 +709,7 @@ public class Reflection {
       if (characterName != null) characterName.setAccessible(true);
       if (characterId != null) characterId.setAccessible(true);
       if (characterDisplayName != null) characterDisplayName.setAccessible(true);
+      if (characterLevel != null) characterLevel.setAccessible(true);
       if (characterX != null) characterX.setAccessible(true);
       if (characterY != null) characterY.setAccessible(true);
       if (characterDamageTaken != null) characterDamageTaken.setAccessible(true);

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -469,6 +469,27 @@ public class Renderer {
               if (isOwnName) {
                 showName = Settings.SHOW_OWN_NAME_OVERLAY.get(Settings.currentProfile);
               } else {
+                if (Settings.SHOW_PVP_NAME_OVERLAY.get(Settings.currentProfile)) {
+                  if (Client.is_in_wild && npc.getWildernessLevel() > 0) {
+                    boolean canAttack = false;
+
+                    if (Client.wild_level >= npc.getWildernessLevel()) {
+                      if (Math.abs(Client.getPlayerLevel() - npc.level)
+                          <= npc.getWildernessLevel()) {
+                        canAttack = true;
+                      }
+                    } else {
+                      if (Math.abs(Client.getPlayerLevel() - npc.level) <= Client.wild_level) {
+                        canAttack = true;
+                      }
+                    }
+
+                    if (canAttack) {
+                      color =
+                          Util.intToColor(Settings.PVP_NAMES_COLOUR.get(Settings.currentProfile));
+                    }
+                  }
+                }
                 showName = true;
               }
             }


### PR DESCRIPTION
This feature adds an option to highlight players' overhead names with a special colour when they are within your level range in the wilderness:

![Screenshot from 2023-04-22 22 21 43](https://user-images.githubusercontent.com/16803725/233818038-024d4d8b-da86-4810-aeb7-b60b17a72f2e.png)

The calculation used to determine whether the other player is attackable takes into account both players' current wilderness levels; in other words, it is a status indicator of whether they are **currently** dangerous to you and **not** whether you could attack them _if_ you were to advance to their wilderness level. 

For instance, if I am a combat level 12 character standing in wilderness level 1, and my opponent is a combat level 10 character standing in wilderness level 2, the other player's name will **not** be highlighted, as neither player can currently attack the other. This is despite the fact that if I were to move forward to stand adjacent to them in level 2 wilderness, I could _then_ begin attacking them.

This methodology felt the most natural to me; in the wilderness, I want to know who is an immediate thread to me and whom I can safely ignore. Especially in a real-world setting, characters are frequently moving about and I believe that it would be a hindrance to additionally highlight players who could be attacked if and only if you were to advance next to them. As such, this methodology is also indicative of whether or not you can begin attacking them with ranged or magic damage from where you are currently standing.

With all of that said, I believe it is important to disclose that I am not personally experienced in PvP and am open to suggestions for modifying the actual calculation; doing so would also be relatively trivial, as it was the smallest part of this overall effort.

Note that the overlay colour itself is customizable in the settings:

![Screenshot_2023-04-22_22-25-31](https://user-images.githubusercontent.com/16803725/233818069-9d2b12d5-af5b-4e18-addc-c1afd1c5ce85.png)
