### PR TITLE
Rebind debug overlay toggle key combo

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -3050,12 +3050,14 @@ public class ConfigWindow {
         "toggle_health_regen_timer",
         KeyModifier.CTRL,
         KeyEvent.VK_X);
-    addKeybindSet(
-        keybindContainerPanel,
-        "Toggle debug mode",
-        "toggle_debug",
-        KeyModifier.CTRL,
-        KeyEvent.VK_D);
+    // TODO: When replaced with upcoming "show items kept on death"
+    //  feature, bind to CTRL+D and add to resolveNewDefaults()
+    //    addKeybindSet(
+    //        keybindContainerPanel,
+    //        "Toggle debug mode",
+    //        "toggle_debug",
+    //        KeyModifier.CTRL,
+    //        KeyEvent.VK_D);
     addKeybindSet(
         keybindContainerPanel,
         "Toggle Wiki Hbar Button",

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -4122,9 +4122,6 @@ public class Settings {
       case "toggle_combat_xp_menu":
         Settings.toggleCombatMenuShown();
         return true;
-      case "toggle_debug":
-        Settings.toggleDebug();
-        return true;
       case "toggle_fatigue_alert":
         Settings.toggleFatigueAlert();
         return true;

--- a/src/Game/KeyboardHandler.java
+++ b/src/Game/KeyboardHandler.java
@@ -56,7 +56,7 @@ public class KeyboardHandler implements KeyListener {
 
     boolean altgr = e.isControlDown() && e.isAltDown() || e.isAltGraphDown();
 
-    // Handle CTRL + Alt
+    // Handle CTRL + Alt modifiers
     //  Note: KeybindSet does not support multiple modifiers
     if (e.isControlDown() && e.isAltDown() && !e.isAltGraphDown()) {
 

--- a/src/Game/KeyboardHandler.java
+++ b/src/Game/KeyboardHandler.java
@@ -52,14 +52,26 @@ public class KeyboardHandler implements KeyListener {
   // TODO: Make spacebar clear the login message screen
   @Override
   public void keyPressed(KeyEvent e) {
-    boolean shouldConsume;
+    boolean shouldConsume = false;
 
-    boolean altgr = false;
-    if (e.isControlDown() && e.isAltDown() || e.isAltGraphDown()) {
-      altgr = true;
-    }
+    boolean altgr = e.isControlDown() && e.isAltDown() || e.isAltGraphDown();
 
-    if (e.isControlDown() && !altgr) {
+    // Handle CTRL + Alt
+    //  Note: KeybindSet does not support multiple modifiers
+    if (e.isControlDown() && e.isAltDown() && !e.isAltGraphDown()) {
+
+      // Special debug key combo
+      if (e.getKeyCode() == KeyEvent.VK_D) {
+        Settings.toggleDebug();
+        shouldConsume = true;
+      }
+
+      if (shouldConsume) {
+        e.consume();
+      }
+
+      // Handle CTRL modifier
+    } else if (e.isControlDown() && !altgr) {
       for (KeybindSet kbs : keybindSetList) {
         if (kbs.getModifier() == KeyModifier.CTRL && e.getKeyCode() == kbs.getKey()) {
           shouldConsume = Settings.processKeybindCommand(kbs.getCommandName());
@@ -69,6 +81,7 @@ public class KeyboardHandler implements KeyListener {
         }
       }
 
+      // Handle shift modifier
     } else if (e.isShiftDown()) {
       for (KeybindSet kbs : keybindSetList) {
         if (kbs.getModifier() == KeyModifier.SHIFT && e.getKeyCode() == kbs.getKey()) {
@@ -79,6 +92,7 @@ public class KeyboardHandler implements KeyListener {
         }
       }
 
+      // Handle Alt modifier
     } else if (e.isAltDown() && !altgr) {
       for (KeybindSet kbs : keybindSetList) {
         if (kbs.getModifier() == KeyModifier.ALT && e.getKeyCode() == kbs.getKey()) {
@@ -89,6 +103,7 @@ public class KeyboardHandler implements KeyListener {
         }
       }
 
+      // Handle all other keys
     } else {
       for (KeybindSet kbs : keybindSetList) {
         if (kbs.getModifier() == KeyModifier.NONE && e.getKeyCode() == kbs.getKey()) {
@@ -100,11 +115,13 @@ public class KeyboardHandler implements KeyListener {
       }
     }
 
+    // Handle replay key captures
     if (Replay.isRecording && !e.isConsumed()) {
       Replay.dumpKeyboardInput(
           e.getKeyCode(), Replay.KEYBOARD_PRESSED, e.getKeyChar(), e.getModifiers());
     }
 
+    // Handle dialogue menu selection
     if (Client.show_questionmenu && !e.isConsumed() && !Replay.isPlaying) {
       if (e.getKeyCode() == KeyEvent.VK_1 || e.getKeyCode() == KeyEvent.VK_NUMPAD1)
         dialogue_option = 0;


### PR DESCRIPTION
Rebinds the debug overlay toggle from `CTRL+D` to `CTRL+ALT+D` to decrease the possibility that a user would accidentally display the debug overlay.

Note: the KeybindSet class does not support multiple keybinds, so this had to be handled specially, which is probably better for a power-user command such as this.