### PR TITLE
Exact match support for block and highlight lists

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1888,6 +1888,9 @@ public class ConfigWindow {
         addCheckbox("Display the names of items on the ground", overlayPanel);
     overlayPanelItemNamesCheckbox.setToolTipText("Shows the names of dropped items");
 
+    String itemInputToolTip =
+        "Surround with \" \" for exact matches (not case-sensitive). Block list takes priority over highlight list.";
+
     // Blocked Items
     JPanel blockedItemsPanel = new JPanel();
     overlayPanel.add(blockedItemsPanel);
@@ -1895,6 +1898,7 @@ public class ConfigWindow {
     blockedItemsPanel.setPreferredSize(new Dimension(0, 37));
     blockedItemsPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     blockedItemsPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
+    blockedItemsPanel.setToolTipText(itemInputToolTip);
 
     JLabel blockedItemsPanelNameLabel = new JLabel("Blocked items: ");
     blockedItemsPanel.add(blockedItemsPanelNameLabel);
@@ -1905,6 +1909,7 @@ public class ConfigWindow {
     blockedItemsTextField.setMinimumSize(new Dimension(100, 28));
     blockedItemsTextField.setMaximumSize(new Dimension(Short.MAX_VALUE, 28));
     blockedItemsTextField.setAlignmentY((float) 0.75);
+    blockedItemsTextField.setToolTipText(itemInputToolTip);
 
     // Highlighted Items
     JPanel highlightedItemsPanel = new JPanel();
@@ -1913,6 +1918,7 @@ public class ConfigWindow {
     highlightedItemsPanel.setPreferredSize(new Dimension(0, 37));
     highlightedItemsPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
     highlightedItemsPanel.setBorder(new EmptyBorder(0, 0, 9, 0));
+    highlightedItemsPanel.setToolTipText(itemInputToolTip);
 
     JLabel highlightedItemsPanelNameLabel = new JLabel("Highlighted items: ");
     highlightedItemsPanel.add(highlightedItemsPanelNameLabel);
@@ -1923,6 +1929,7 @@ public class ConfigWindow {
     highlightedItemsTextField.setMinimumSize(new Dimension(100, 28));
     highlightedItemsTextField.setMaximumSize(new Dimension(Short.MAX_VALUE, 28));
     highlightedItemsTextField.setAlignmentY((float) 0.75);
+    highlightedItemsTextField.setToolTipText(itemInputToolTip);
 
     // Highlight colour panel
     JPanel overlayPanelItemHighlightColourPanel = new JPanel();

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -179,7 +179,7 @@ public class Item {
         boolean addingAnItem = (remove & 0x80) >> 7 != 1;
         if (addingAnItem) {
           if (Renderer.stringIsWithinList(
-              item_name[itemId], Settings.HIGHLIGHTED_ITEMS.get("custom"))) {
+              item_name[itemId], Settings.HIGHLIGHTED_ITEMS.get("custom"), true)) {
             cool_items.add(new Item(x, y, itemId, System.currentTimeMillis()));
           }
         } else {

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -601,7 +601,7 @@ public class Renderer {
 
             // Check if item is in blocked list
             boolean itemIsBlocked =
-                stringIsWithinList(item.getName(), Settings.BLOCKED_ITEMS.get("custom"));
+                stringIsWithinList(item.getName(), Settings.BLOCKED_ITEMS.get("custom"), true);
 
             // We've sorted item list in such a way that it is possible to not draw the ITEMINFO
             // unless it's the first time we've tried to for this itemid at that location
@@ -622,7 +622,8 @@ public class Renderer {
               String itemText = item.getName() + ((freq == 1) ? "" : " (" + freq + ")");
 
               // Check if item is in highlighted list
-              if (itemInHighlightList(item.getName())) {
+              if (Renderer.stringIsWithinList(
+                  item.getName(), Settings.HIGHLIGHTED_ITEMS.get("custom"), true)) {
                 itemColor =
                     Util.intToColor(Settings.ITEM_HIGHLIGHT_COLOUR.get(Settings.currentProfile));
                 drawHighlightImage(g2, itemText, x, y);
@@ -2398,10 +2399,22 @@ public class Renderer {
     g.setComposite(AlphaComposite.SrcOver.derive(alpha));
   }
 
+  // Method hooked in JClassPatcher
   public static boolean itemInHighlightList(String itemName) {
-    return Renderer.stringIsWithinList(itemName, Settings.HIGHLIGHTED_ITEMS.get("custom"));
+    // Strip color if the name comes from the right-click menu
+    if (itemName.startsWith("@lre@")) {
+      itemName = itemName.substring(5);
+    }
+
+    // Ignore blocked items
+    if (stringIsWithinList(itemName, Settings.BLOCKED_ITEMS.get("custom"), true)) {
+      return false;
+    }
+
+    return Renderer.stringIsWithinList(itemName, Settings.HIGHLIGHTED_ITEMS.get("custom"), true);
   }
 
+  // Method hooked in JClassPatcher
   public static void setRightClickMenuBounds(int x, int y, int width, int height) {
     rightClickMenuX = x;
     rightClickMenuY = y;
@@ -2409,16 +2422,45 @@ public class Renderer {
     rightClickMenuHeight = height;
   }
 
+  /**
+   * Checks if a given string is contained within a list of strings. When surrounded by quotes,
+   * input strings will not check for exact matches and the quotes will be treated as part of the
+   * input string.
+   *
+   * @param input Input string
+   * @param items {@link ArrayList} of Strings
+   * @return {@code boolean} if the string is found
+   */
   public static boolean stringIsWithinList(String input, ArrayList<String> items) {
+    return stringIsWithinList(input, items, false);
+  }
+
+  /**
+   * Checks if a given string is contained within a list of strings.
+   *
+   * @param input Input string
+   * @param items {@link ArrayList} of Strings
+   * @param checkExactMatches {@code boolean} indicating whether to check for exact matches when the
+   *     input string is surrounded with quotes.
+   * @return {@code boolean} if the string is found
+   */
+  public static boolean stringIsWithinList(
+      String input, ArrayList<String> items, boolean checkExactMatches) {
     if (items.size() <= 0) {
       return false;
     }
     Iterator it = items.iterator();
     while (it.hasNext()) {
-      String item = String.valueOf(it.next());
-      if (item.trim().length() > 0
-          && input.trim().toLowerCase().contains(item.trim().toLowerCase())) {
-        return true;
+      String item = String.valueOf(it.next()).trim();
+      if (item.length() > 0) {
+        if (checkExactMatches
+            && item.startsWith("\"")
+            && item.endsWith("\"")
+            && input.trim().equalsIgnoreCase(item.substring(1, item.length() - 1))) {
+          return true;
+        } else if (input.trim().toLowerCase().contains(item.toLowerCase())) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
Adds exact-match support to the block and highlight item lists via surrounding double quotation marks (not case-sensitive).

Allows players to have more fine-grained control, such as being able to specifically block basic `"bones"` without also blocking other types.