### PR TITLE
Option to only show highlighted ground items

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -3680,7 +3680,13 @@ public class ConfigWindow {
         "Toggle item name overlay",
         "toggle_item_overlay",
         KeyModifier.CTRL,
-        KeyEvent.VK_I);
+        KeyEvent.VK_G);
+    addKeybindSet(
+        keybindContainerPanel,
+        "Toggle item name overlay (highlighted only)",
+        "toggle_item_overlay_highlight",
+        KeyModifier.ALT,
+        KeyEvent.VK_G);
     addKeybindSet(
         keybindContainerPanel,
         "Toggle player name overlay",
@@ -3711,12 +3717,6 @@ public class ConfigWindow {
         "toggle_hitboxes",
         KeyModifier.CTRL,
         KeyEvent.VK_H);
-    addKeybindSet(
-        keybindContainerPanel,
-        "Toggle food heal overlay",
-        "toggle_food_heal_overlay",
-        KeyModifier.CTRL,
-        KeyEvent.VK_G);
     addKeybindSet(
         keybindContainerPanel,
         "Toggle time until health regen",

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -3484,6 +3484,7 @@ public class ConfigWindow {
     gbl_constraints.fill = GridBagConstraints.HORIZONTAL;
     gbl_constraints.anchor = GridBagConstraints.FIRST_LINE_START;
     gbl_constraints.weightx = 1;
+    gbl_constraints.ipadx = 20;
     gbl_constraints.gridy = 0;
     gbl_constraints.gridwidth = 3;
 
@@ -3678,13 +3679,13 @@ public class ConfigWindow {
     addKeybindSet(
         keybindContainerPanel,
         "Toggle item name overlay",
-        "toggle_item_overlay",
+        "toggle_item_name_overlay",
         KeyModifier.CTRL,
         KeyEvent.VK_G);
     addKeybindSet(
         keybindContainerPanel,
         "Toggle item name overlay (highlighted only)",
-        "toggle_item_overlay_highlight",
+        "toggle_item_name_overlay_highlight",
         KeyModifier.ALT,
         KeyEvent.VK_G);
     addKeybindSet(

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -281,6 +281,7 @@ public class ConfigWindow {
   private JCheckBox overlayPanelPositionCheckbox;
   private JCheckBox overlayPanelRetroFpsCheckbox;
   private JCheckBox overlayPanelItemNamesCheckbox;
+  private JCheckBox overlayPanelItemNamesHighlightedOnlyCheckbox;
   private JCheckBox overlayPanelPlayerNamesCheckbox;
   private JCheckBox overlayPanelPvpNamesCheckbox;
   private JPanel overlayPanelPvpNamesColourSubpanel;
@@ -2308,6 +2309,11 @@ public class ConfigWindow {
     overlayPanelItemNamesCheckbox =
         addCheckbox("Display the names of items on the ground", overlayPanelGroundItemsPanel);
     overlayPanelItemNamesCheckbox.setToolTipText("Shows the names of dropped items");
+
+    overlayPanelItemNamesHighlightedOnlyCheckbox =
+        addCheckbox("Only display highlighted items", overlayPanelGroundItemsPanel);
+    overlayPanelItemNamesHighlightedOnlyCheckbox.setToolTipText(
+        "Will only show items in the highlighted list below");
 
     String itemInputToolTip =
         "Surround with \" \" for exact matches (not case-sensitive). Block list takes priority over highlight list.";
@@ -5338,6 +5344,8 @@ public class ConfigWindow {
     overlayPanelRetroFpsCheckbox.setSelected(Settings.SHOW_RETRO_FPS.get(Settings.currentProfile));
     overlayPanelItemNamesCheckbox.setSelected(
         Settings.SHOW_ITEM_GROUND_OVERLAY.get(Settings.currentProfile));
+    overlayPanelItemNamesHighlightedOnlyCheckbox.setSelected(
+        Settings.SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(Settings.currentProfile));
     overlayPanelPlayerNamesCheckbox.setSelected(
         Settings.SHOW_PLAYER_NAME_OVERLAY.get(Settings.currentProfile));
     overlayPanelPvpNamesCheckbox.setSelected(
@@ -5801,6 +5809,8 @@ public class ConfigWindow {
     Settings.SHOW_RETRO_FPS.put(Settings.currentProfile, overlayPanelRetroFpsCheckbox.isSelected());
     Settings.SHOW_ITEM_GROUND_OVERLAY.put(
         Settings.currentProfile, overlayPanelItemNamesCheckbox.isSelected());
+    Settings.SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put(
+        Settings.currentProfile, overlayPanelItemNamesHighlightedOnlyCheckbox.isSelected());
     Settings.SHOW_PLAYER_NAME_OVERLAY.put(
         Settings.currentProfile, overlayPanelPlayerNamesCheckbox.isSelected());
     Settings.SHOW_PVP_NAME_OVERLAY.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2761,6 +2761,24 @@ public class Settings {
           break;
         }
       }
+      // 08/16/2023 - toggle_item_overlay was rebound from ctrl-i to ctrl-g
+      if (keybind.getCommandName().equals("toggle_item_overlay")) {
+        if (keybind.getModifier().equals(KeyModifier.CTRL) && keybind.getKey() == KeyEvent.VK_I) {
+          keybind.setModifier(KeyModifier.CTRL);
+          keybind.setKey(KeyEvent.VK_G);
+
+          break;
+        }
+      }
+      // 08/16/2023 - toggle_food_heal_overlay was removed
+      if (keybind.getCommandName().equals("toggle_food_heal_overlay")) {
+        if (keybind.getModifier().equals(KeyModifier.CTRL) && keybind.getKey() == KeyEvent.VK_G) {
+          keybind.setModifier(null);
+          keybind.setKey(-1);
+
+          break;
+        }
+      }
     }
   }
 
@@ -3717,10 +3735,27 @@ public class Settings {
   public static void toggleShowItemGroundOverlay() {
     SHOW_ITEM_GROUND_OVERLAY.put(currentProfile, !SHOW_ITEM_GROUND_OVERLAY.get(currentProfile));
 
+    String baseMessageOn = "@cya@Ground item names are now shown";
+    String highlightOnlyMessage = " (Highlighted only)";
+
+    boolean highlightOnlyOff = !Settings.SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(currentProfile);
+
     if (SHOW_ITEM_GROUND_OVERLAY.get(currentProfile)) {
-      Client.displayMessage("@cya@Ground item names are now shown", Client.CHAT_NONE);
+      Client.displayMessage(highlightOnlyOff ? baseMessageOn : baseMessageOn + highlightOnlyMessage, Client.CHAT_NONE);
     } else {
       Client.displayMessage("@cya@Ground item names are now hidden", Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
+  public static void toggleShowItemGroundHighlightOnlyOverlay() {
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put(currentProfile, !SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(currentProfile));
+
+    if (SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(currentProfile)) {
+      Client.displayMessage("@cya@Only highlighted ground item names will be shown when enabled", Client.CHAT_NONE);
+    } else {
+      Client.displayMessage("@cya@All ground item names will be shown when enabled", Client.CHAT_NONE);
     }
 
     save();
@@ -4309,6 +4344,9 @@ public class Settings {
         return true;
       case "toggle_item_overlay":
         Settings.toggleShowItemGroundOverlay();
+        return true;
+      case "toggle_item_overlay_highlight":
+        Settings.toggleShowItemGroundHighlightOnlyOverlay();
         return true;
       case "toggle_hitboxes":
         Settings.toggleShowHitbox();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -233,6 +233,8 @@ public class Settings {
   public static HashMap<String, Boolean> REMOVE_REPORT_ABUSE_BUTTON_HBAR =
       new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_ITEM_GROUND_OVERLAY = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY =
+      new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_PLAYER_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_PVP_NAME_OVERLAY = new HashMap<String, Boolean>();
   public static HashMap<String, Integer> PVP_NAMES_COLOUR = new HashMap<String, Integer>();
@@ -1720,6 +1722,19 @@ public class Settings {
     SHOW_ITEM_GROUND_OVERLAY.put(
         "custom", getPropBoolean(props, "show_iteminfo", SHOW_ITEM_GROUND_OVERLAY.get("default")));
 
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("vanilla", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("vanilla_resizable", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("lite", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("default", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("heavy", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put("all", false);
+    SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.put(
+        "custom",
+        getPropBoolean(
+            props,
+            "show_iteminfo_highlighted",
+            SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get("default")));
+
     SHOW_PLAYER_NAME_OVERLAY.put("vanilla", false);
     SHOW_PLAYER_NAME_OVERLAY.put("vanilla_resizable", false);
     SHOW_PLAYER_NAME_OVERLAY.put("lite", false);
@@ -3148,6 +3163,9 @@ public class Settings {
           "toggle_xp_bar_on_stats_button",
           Boolean.toString(TOGGLE_XP_BAR_ON_STATS_BUTTON.get(preset)));
       props.setProperty("show_iteminfo", Boolean.toString(SHOW_ITEM_GROUND_OVERLAY.get(preset)));
+      props.setProperty(
+          "show_iteminfo_highlighted",
+          Boolean.toString(SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(preset)));
       props.setProperty("show_playerinfo", Boolean.toString(SHOW_PLAYER_NAME_OVERLAY.get(preset)));
       props.setProperty("show_pvpinfo", Boolean.toString(SHOW_PVP_NAME_OVERLAY.get(preset)));
       props.setProperty("pvp_names_colour", Integer.toString(PVP_NAMES_COLOUR.get(preset)));

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2761,15 +2761,7 @@ public class Settings {
           break;
         }
       }
-      // 08/16/2023 - toggle_item_overlay was rebound from ctrl-i to ctrl-g
-      if (keybind.getCommandName().equals("toggle_item_overlay")) {
-        if (keybind.getModifier().equals(KeyModifier.CTRL) && keybind.getKey() == KeyEvent.VK_I) {
-          keybind.setModifier(KeyModifier.CTRL);
-          keybind.setKey(KeyEvent.VK_G);
 
-          break;
-        }
-      }
       // 08/16/2023 - toggle_food_heal_overlay was removed
       if (keybind.getCommandName().equals("toggle_food_heal_overlay")) {
         if (keybind.getModifier().equals(KeyModifier.CTRL) && keybind.getKey() == KeyEvent.VK_G) {
@@ -4342,10 +4334,10 @@ public class Settings {
       case "endrun":
         Settings.endSpeedrun();
         return true;
-      case "toggle_item_overlay":
+      case "toggle_item_name_overlay":
         Settings.toggleShowItemGroundOverlay();
         return true;
-      case "toggle_item_overlay_highlight":
+      case "toggle_item_name_overlay_highlight":
         Settings.toggleShowItemGroundHighlightOnlyOverlay();
         return true;
       case "toggle_hitboxes":

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -566,8 +566,12 @@ public class Renderer {
         List<Rectangle> item_hitbox = new ArrayList<>();
         List<Point> item_text_loc = new ArrayList<>();
 
-        if (Settings.SHOW_ITEM_GROUND_OVERLAY.get(
-            Settings.currentProfile)) { // Don't sort if we aren't displaying any item names anyway
+        boolean showItemGroundOverlay =
+            Settings.SHOW_ITEM_GROUND_OVERLAY.get(Settings.currentProfile);
+        boolean showItemGroundOverlayHighlightedOnly =
+            Settings.SHOW_ITEM_GROUND_OVERLAY_HIGHLIGHTED_ONLY.get(Settings.currentProfile);
+
+        if (showItemGroundOverlay) { // Don't sort if we aren't displaying any item names anyway
           try {
             // Keep items in (technically reverse) alphabetical order for SHOW_ITEMINFO instead of
             // randomly changing places each frame
@@ -606,14 +610,20 @@ public class Renderer {
             }
           }
 
-          if (Settings.SHOW_ITEM_GROUND_OVERLAY.get(Settings.currentProfile)) {
+          if (showItemGroundOverlay) {
             int x = item.x + (item.width / 2);
             int y = item.y - 20;
             int freq = Collections.frequency(Client.item_list, item);
 
-            // Check if item is in blocked list
+            String itemName = item.getName();
+            boolean itemInHighlightList =
+                stringIsWithinList(itemName, Settings.HIGHLIGHTED_ITEMS.get("custom"), true);
+
+            // Check if item is in blocked list or if the highlighted only setting is active and
+            // item is not in the list
             boolean itemIsBlocked =
-                stringIsWithinList(item.getName(), Settings.BLOCKED_ITEMS.get("custom"), true);
+                stringIsWithinList(itemName, Settings.BLOCKED_ITEMS.get("custom"), true)
+                    || (showItemGroundOverlayHighlightedOnly && !itemInHighlightList);
 
             // We've sorted item list in such a way that it is possible to not draw the ITEMINFO
             // unless it's the first time we've tried to for this itemid at that location
@@ -631,11 +641,10 @@ public class Renderer {
               item_text_loc.add(new Point(x, y));
 
               Color itemColor = color_item;
-              String itemText = item.getName() + ((freq == 1) ? "" : " (" + freq + ")");
+              String itemText = itemName + ((freq == 1) ? "" : " (" + freq + ")");
 
               // Check if item is in highlighted list
-              if (Renderer.stringIsWithinList(
-                  item.getName(), Settings.HIGHLIGHTED_ITEMS.get("custom"), true)) {
+              if (itemInHighlightList) {
                 itemColor =
                     Util.intToColor(Settings.ITEM_HIGHLIGHT_COLOUR.get(Settings.currentProfile));
                 drawHighlightImage(g2, itemText, x, y);


### PR DESCRIPTION
Adds a new option for only displaying ground item names for items in your highlight list