### PR TITLE
Changed FPS display to use native mudclient logic

### DIFF
--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -1087,6 +1087,25 @@ public class JClassPatcher {
             methodNode.instructions.insert(insnNode, new InsnNode(Opcodes.RETURN));
           }
         }
+
+        insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+          AbstractInsnNode nextNode = insnNode.getNext();
+
+          // entry point
+          if (insnNode.getOpcode() == Opcodes.INVOKEVIRTUAL
+              && ((MethodInsnNode) insnNode).name.equals("b")) {
+            methodNode.instructions.insertBefore(nextNode, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(
+                nextNode, new FieldInsnNode(Opcodes.GETFIELD, "e", "Ib", "I"));
+            methodNode.instructions.insertBefore(nextNode, new VarInsnNode(Opcodes.ILOAD, 4));
+            methodNode.instructions.insertBefore(
+                nextNode,
+                new MethodInsnNode(Opcodes.INVOKESTATIC, "Game/Client", "calcFPS", "(II)V"));
+            break;
+          }
+        }
       }
 
       // draw loading screen

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -271,6 +271,8 @@ public class Client {
   public static int selectedItemSlot;
   public static boolean is_hover;
 
+  public static int fps;
+
   /** An array of Strings that stores text used in the client */
   public static String[] strings;
 
@@ -805,6 +807,11 @@ public class Client {
     }
 
     return skipToLogin || Settings.START_LOGINSCREEN.get(Settings.currentProfile);
+  }
+
+  /** Early OG Mudclient FPS calculation to display when Settings.SHOW_RETRO_FPS is set */
+  public static void calcFPS(int target, int var1) {
+    fps = (1000 * var1) / (target * 256);
   }
 
   /**
@@ -2475,7 +2482,7 @@ public class Client {
         try {
           Reflection.drawString.invoke(
               surfaceInstance,
-              "Fps: " + Renderer.fps,
+              "Fps: " + Client.fps,
               Renderer.width - 62 - offset,
               Renderer.height - 19,
               0xffff00,

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -809,9 +809,15 @@ public class Client {
     return skipToLogin || Settings.START_LOGINSCREEN.get(Settings.currentProfile);
   }
 
-  /** Early OG Mudclient FPS calculation to display when Settings.SHOW_RETRO_FPS is set */
-  public static void calcFPS(int target, int var1) {
-    fps = (1000 * var1) / (target * 256);
+  /**
+   * Early OG Mudclient FPS calculation to display when Settings.SHOW_RETRO_FPS is set The fps will
+   * be between [4, 50]
+   *
+   * @param targetFrameTime - the target frameTime in milliseconds per frame
+   * @param frameCounter counter between [25, 256]
+   */
+  public static void calcFPS(int targetFrameTime, int frameCounter) {
+    fps = (1000 * frameCounter) / (targetFrameTime * 256);
   }
 
   /**


### PR DESCRIPTION
Believe we should change towards displaying fps using what the mudclient has to report instead of our own calculated fps, since is more authentic and potentially more accurate. On the variables used not sure what proper naming would be @conker-rsc @Hubcapp . For reference in mudclient 40 fps computation is https://bitbucket.org/eggsampler/rsc/src/bca75cc4bd27fd5d2460d5ae4ffc4484253da21f/40/src/jagex/client/GameApplet.java#lines-438