### PR TITLE
Including native mudclient fps calculation for retro fps display

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,8 +7,10 @@
 	<classpathentry kind="lib" path="lib/asm-tree-5.0.4.jar"/>
 	<classpathentry kind="lib" path="lib/asm-util-5.0.4.jar"/>
 	<classpathentry kind="lib" path="lib/jansi-1.18.jar"/>
+	<classpathentry kind="lib" path="lib/jinput-2.0.9.jar"/>
 	<classpathentry kind="lib" path="lib/commons-compress-1.18.jar"/>
 	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/json-20201115.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
 	<classpathentry kind="lib" path="lib/activation.jar"/>
 	<classpathentry kind="lib" path="lib/jsoup-1.16.1.jar"/>

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -1087,6 +1087,31 @@ public class JClassPatcher {
             methodNode.instructions.insert(insnNode, new InsnNode(Opcodes.RETURN));
           }
         }
+
+        insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+          AbstractInsnNode nextNode = insnNode.getNext();
+
+          // entry point
+          if (insnNode.getOpcode() == Opcodes.INVOKEVIRTUAL
+              && ((MethodInsnNode) insnNode).name.equals("b")) {
+            methodNode.instructions.insertBefore(nextNode, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(nextNode, new IntInsnNode(Opcodes.SIPUSH, 1000));
+            methodNode.instructions.insertBefore(nextNode, new VarInsnNode(Opcodes.ILOAD, 4));
+            methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.IMUL));
+            methodNode.instructions.insertBefore(nextNode, new VarInsnNode(Opcodes.ALOAD, 0));
+            methodNode.instructions.insertBefore(
+                nextNode, new FieldInsnNode(Opcodes.GETFIELD, "e", "Ib", "I"));
+            methodNode.instructions.insertBefore(nextNode, new IntInsnNode(Opcodes.SIPUSH, 256));
+            methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.IMUL));
+            methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.IDIV));
+            methodNode.instructions.insertBefore(
+                nextNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "fps", "I"));
+            methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.POP));
+            break;
+          }
+        }
       }
 
       // draw loading screen

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -271,6 +271,8 @@ public class Client {
   public static int selectedItemSlot;
   public static boolean is_hover;
 
+  public static int fps;
+
   /** An array of Strings that stores text used in the client */
   public static String[] strings;
 
@@ -2475,7 +2477,7 @@ public class Client {
         try {
           Reflection.drawString.invoke(
               surfaceInstance,
-              "Fps: " + Renderer.fps,
+              "Fps: " + Client.fps,
               Renderer.width - 62 - offset,
               Renderer.height - 19,
               0xffff00,


### PR DESCRIPTION
Like #172 but this one just feels better to have since avoids unnecessary calc exposure on Client class. For reference on bytecode used on mudclient38 where it calculates fps:

![image](https://github.com/RSCPlus/rscplus/assets/10690767/5fe0513a-46b3-47c0-ac0c-5a911582a1d9)
