### PR TITLE
Fix native fps to prevent divide by 0

### DIFF
--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -1105,6 +1105,11 @@ public class JClassPatcher {
                 nextNode, new FieldInsnNode(Opcodes.GETFIELD, "e", "Ib", "I"));
             methodNode.instructions.insertBefore(nextNode, new IntInsnNode(Opcodes.SIPUSH, 256));
             methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.IMUL));
+            // added to prevent seeks div by 0
+            methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.ICONST_1));
+            methodNode.instructions.insertBefore(
+                nextNode,
+                new MethodInsnNode(Opcodes.INVOKESTATIC, "java/lang/Math", "max", "(II)I", false));
             methodNode.instructions.insertBefore(nextNode, new InsnNode(Opcodes.IDIV));
             methodNode.instructions.insertBefore(
                 nextNode, new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "fps", "I"));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2477,7 +2477,10 @@ public class Client {
         try {
           Reflection.drawString.invoke(
               surfaceInstance,
-              "Fps: " + Client.fps,
+              "Fps: "
+                  + (Client.username_login.equals(XPBar.excludeUsername)
+                      ? Renderer.fps
+                      : Client.fps),
               Renderer.width - 62 - offset,
               Renderer.height - 19,
               0xffff00,


### PR DESCRIPTION
This fixes crash of divide by 0 on seeks since target frameTime is set to 0. Also sets to use Render.fps when replaying.