### PR TITLE
Cmb styles per-char, custom dir settings, rolling logs, various fixes

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -54,6 +54,10 @@ import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.SystemTray;
 import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.AWTEventListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -82,8 +86,10 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -95,6 +101,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JColorChooser;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -261,6 +268,7 @@ public class ConfigWindow {
   private JSpinner generalPanelLimitFPSSpinner;
   private JSpinner generalPanelLimitRanFPSSpinner;
   private JCheckBox generalPanelAutoScreenshotCheckbox;
+  private JTextField generalPanelScreenshotsDirTextField;
   private JCheckBox generalPanelRS2HDSkyCheckbox;
   private JCheckBox generalPanelCustomSkyboxOverworldCheckbox;
   private JPanel generalPanelSkyOverworldColourColourPanel;
@@ -426,6 +434,7 @@ public class ConfigWindow {
   // private JTextField streamingPanelSpeedrunnerUsernameTextField;
 
   //// Replay tab
+  private JTextField replayPanelReplayStoragePathTextField;
   private JCheckBox replayPanelRecordKBMouseCheckbox;
   private JCheckBox replayPanelParseOpcodesCheckbox;
   private JCheckBox replayPanelFastDisconnectCheckbox;
@@ -435,7 +444,7 @@ public class ConfigWindow {
   private JCheckBox replayPanelShowPlayerControlsCheckbox;
   private JCheckBox replayPanelTriggerAlertsReplayCheckbox;
   private JTextField replayPanelDateFormatTextField;
-  private JTextField replayPanelReplayFolderBasePathTextField;
+  private JTextField replayPanelReplayBasePathTextField;
   private JCheckBox replayPanelShowWorldColumnCheckbox;
   private JCheckBox replayPanelShowConversionSettingsCheckbox;
   private JCheckBox replayPanelShowUserFieldCheckbox;
@@ -469,6 +478,7 @@ public class ConfigWindow {
       new HashMap<Integer, JTextField>();
   private HashMap<Integer, JLabel> worldListSpacingLabels = new HashMap<Integer, JLabel>();
   private JPanel worldListPanel = new JPanel();
+  private JButton addWorldButton;
 
   //// Joystick tab
   private JCheckBox joystickPanelJoystickEnabledCheckbox;
@@ -484,7 +494,7 @@ public class ConfigWindow {
   private boolean reindexing = false;
 
   /** Defines all {@link ConfigWindow} tabs */
-  protected enum ConfigTab {
+  public enum ConfigTab {
     PRESETS("Presets"),
     GENERAL("General"),
     OVERLAYS("Overlays"),
@@ -506,6 +516,25 @@ public class ConfigWindow {
 
     public String getLabel() {
       return label;
+    }
+
+    /**
+     * @return boolean indicating if the provided {@link ConfigTab} is currently selected,
+     *     regardless of whether the tab is currently enabled or not.
+     */
+    public static boolean isTabSelected(ConfigTab tab) {
+      int tabIndex = getTabIndex(tab);
+
+      if (tabIndex == -1) {
+        return false;
+      }
+
+      return Launcher.getConfigWindow().tabbedPane.getSelectedIndex() == tabIndex;
+    }
+
+    /** @return the tab index value for the provided {@link ConfigTab} or {@code -1} if not found */
+    public static int getTabIndex(ConfigTab tab) {
+      return Launcher.getConfigWindow().tabbedPane.indexOfTab(tab.getLabel());
     }
   }
 
@@ -546,6 +575,85 @@ public class ConfigWindow {
 
   public boolean isShown() {
     return frame.isVisible();
+  }
+
+  /** Drop target handler for drag-and-dropping world ini files */
+  private DropTarget createWorldFileDropTarget() {
+    return new DropTarget() {
+      public synchronized void drop(DropTargetDropEvent evt) {
+        try {
+          if (ConfigTab.isTabSelected(ConfigTab.WORLD_LIST)) {
+            if (evt.getTransferable().isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+              evt.acceptDrop(DnDConstants.ACTION_LINK);
+              List<File> droppedFiles =
+                  (List<File>) evt.getTransferable().getTransferData(DataFlavor.javaFileListFlavor);
+
+              Map<File, Properties> validWorldFileMap = new HashMap<>();
+              List<File> invalidWorldFiles = new ArrayList<>();
+
+              droppedFiles.forEach(
+                  file -> {
+                    Properties fileProps = Settings.validateWorldFile(file);
+                    if (fileProps != null) {
+                      validWorldFileMap.put(file, fileProps);
+                    } else {
+                      invalidWorldFiles.add(file);
+                    }
+                  });
+
+              validWorldFileMap.forEach(
+                  (file, props) -> {
+                    // Add new world fields
+                    addWorldAction();
+
+                    int i = Settings.WORLDS_TO_DISPLAY;
+                    worldNamesJTextFields.get(i).setText(props.getProperty("name"));
+                    worldUrlsJTextFields.get(i).setText(props.getProperty("url"));
+                    worldPortsJTextFields.get(i).setText(props.getProperty("port"));
+                    worldTypesJComboBoxes
+                        .get(i)
+                        .setSelectedIndex(
+                            Integer.parseInt((String) props.getOrDefault("servertype", "1")));
+                    worldRSAPubKeyJTextFields.get(i).setText(props.getProperty("rsa_pub_key"));
+                    worldRSAExponentsJTextFields.get(i).setText(props.getProperty("rsa_exponent"));
+                    worldListHiscoresURLTextFieldContainers
+                        .get(i)
+                        .setText((String) props.getOrDefault("hiscores_url", ""));
+
+                    applySettings();
+                  });
+
+              if (!invalidWorldFiles.isEmpty()) {
+                StringBuilder sb =
+                    new StringBuilder()
+                        .append(
+                            "<html><body>The following files are invalid and could not be imported:<ul>");
+                for (File invalidWorldFile : invalidWorldFiles) {
+                  sb.append("<li>").append(invalidWorldFile.getName()).append("</li>");
+                }
+                sb.append("</ul></body></html>");
+
+                JPanel invalidWorldFilesPanel = Util.createOptionMessagePanel(sb.toString());
+
+                JOptionPane.showMessageDialog(
+                    Launcher.getConfigWindow().frame,
+                    invalidWorldFilesPanel,
+                    "RSCPlus",
+                    JOptionPane.INFORMATION_MESSAGE,
+                    Launcher.scaled_option_icon);
+              }
+            } else {
+              Logger.Info(
+                  "Whatever you just dragged into the settings window, RSC+ doesn't know what to do with it.");
+              Logger.Info("Please report this as a bug on GitHub if you believe it should work.");
+            }
+          }
+        } catch (Exception ex) {
+          Logger.Error("Error in ConfigWindow queue drop handler!");
+          ex.printStackTrace();
+        }
+      }
+    };
   }
 
   /** Initialize the contents of the frame. */
@@ -589,6 +697,8 @@ public class ConfigWindow {
             super.windowClosed(e);
           }
         });
+
+    frame.setDropTarget(createWorldFileDropTarget());
 
     // Container declarations
 
@@ -1000,7 +1110,7 @@ public class ConfigWindow {
             }
 
             try {
-              File configFile = new File(Settings.Dir.JAR + "/config.ini");
+              File configFile = new File(Settings.CONFIG_FILE);
               if (configFile.exists()) {
                 Files.delete(configFile.toPath());
               }
@@ -1477,11 +1587,6 @@ public class ConfigWindow {
     generalPanelTrackpadRotationSlider.setLabelTable(generalPanelTrackpadRotationLabelTable);
     generalPanelTrackpadRotationSlider.setPaintLabels(true);
 
-    generalPanelAutoScreenshotCheckbox =
-        addCheckbox("Take a screenshot when you level up or complete a quest", generalPanel);
-    generalPanelAutoScreenshotCheckbox.setToolTipText(
-        "Takes a screenshot for you for level ups and quest completion");
-
     generalPanelUseJagexFontsCheckBox =
         addCheckbox("Override system font with Jagex fonts", generalPanel);
     generalPanelUseJagexFontsCheckBox.setToolTipText(
@@ -1499,6 +1604,88 @@ public class ConfigWindow {
         addCheckbox("Use xdg-open to open URLs on Linux", generalPanel);
     generalPanelPrefersXdgOpenCheckbox.setToolTipText(
         "Does nothing on Windows or Mac, may improve URL opening experience on Linux");
+
+    generalPanelAutoScreenshotCheckbox =
+        addCheckbox("Take a screenshot when you level up or complete a quest", generalPanel);
+    generalPanelAutoScreenshotCheckbox.setToolTipText(
+        "Takes a screenshot for you for level ups and on quest completion");
+
+    /// Screenshots directory
+
+    float screenshotsButtonAlignment = isUsingFlatLAFTheme() ? 0.75f : 0.8f;
+
+    JPanel generalPanelScreenshotsDirPanel = new JPanel();
+    generalPanel.add(generalPanelScreenshotsDirPanel);
+    generalPanelScreenshotsDirPanel.setLayout(
+        new BoxLayout(generalPanelScreenshotsDirPanel, BoxLayout.X_AXIS));
+    generalPanelScreenshotsDirPanel.setPreferredSize(
+        osScaleMul(new Dimension(0, isUsingFlatLAFTheme() ? 32 : 37)));
+    generalPanelScreenshotsDirPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    generalPanelScreenshotsDirPanel.setBorder(
+        BorderFactory.createEmptyBorder(0, 0, osScaleMul(9), 0));
+
+    JLabel generalPanelScreenshotsDirTextFieldLabel = new JLabel("Save screenshots to: ");
+    generalPanelScreenshotsDirTextFieldLabel.setToolTipText(
+        "Location where your screenshots will be stored");
+    generalPanelScreenshotsDirPanel.add(generalPanelScreenshotsDirTextFieldLabel);
+    generalPanelScreenshotsDirTextFieldLabel.setAlignmentY(isUsingFlatLAFTheme() ? 0.85f : 0.9f);
+
+    generalPanelScreenshotsDirTextField = new JTextField();
+    generalPanelScreenshotsDirPanel.add(generalPanelScreenshotsDirTextField);
+    generalPanelScreenshotsDirTextField.setMinimumSize(osScaleMul(new Dimension(100, 28)));
+    generalPanelScreenshotsDirTextField.setMaximumSize(
+        new Dimension(Short.MAX_VALUE, osScaleMul(28)));
+    generalPanelScreenshotsDirTextField.setAlignmentY(0.75f);
+    generalPanelScreenshotsDirTextField.setToolTipText(
+        "To restore the default location, delete the value and apply settings");
+
+    if (Util.isUsingFlatLAFTheme()) {
+      generalPanelScreenshotsDirPanel.add(Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    File screenshotsDir = new File(Settings.SCREENSHOTS_STORAGE_PATH.get("custom"));
+    JFileChooser screenshotDirChooser = new JFileChooser(screenshotsDir);
+    screenshotDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+
+    JButton generalPanelScreenshotsSetDirButton =
+        addButton("Set", generalPanelScreenshotsDirPanel, Component.RIGHT_ALIGNMENT);
+    generalPanelScreenshotsSetDirButton.setAlignmentY(screenshotsButtonAlignment);
+    generalPanelScreenshotsSetDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            int choice = screenshotDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
+            if (choice == JFileChooser.APPROVE_OPTION) {
+              File screenshotsDir = screenshotDirChooser.getSelectedFile();
+              if (validateChosenDirectory(screenshotsDir)) {
+                reindexSearch(
+                    () -> {
+                      Settings.SCREENSHOTS_STORAGE_PATH.put("custom", screenshotsDir.toString());
+                      screenshotDirChooser.setCurrentDirectory(screenshotsDir);
+                      Settings.save();
+                      synchronizeGuiValues();
+                    });
+              }
+            }
+          }
+        });
+
+    if (Util.isUsingFlatLAFTheme()) {
+      generalPanelScreenshotsDirPanel.add(Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    JButton generalPanelScreenshotsOpenDirButton =
+        addButton("Open", generalPanelScreenshotsDirPanel, Component.RIGHT_ALIGNMENT);
+    generalPanelScreenshotsOpenDirButton.setAlignmentY(screenshotsButtonAlignment);
+    generalPanelScreenshotsOpenDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.SCREENSHOTS_STORAGE_PATH.get("custom")));
+          }
+        });
+
+    ///
 
     /// "Gameplay settings" are settings that can be seen inside the game
     addSettingsHeader(generalPanel, "Gameplay settings");
@@ -1732,6 +1919,8 @@ public class ConfigWindow {
         addCheckbox("Disable underground lighting flicker", generalPanel);
     generalPanelDisableUndergroundLightingCheckbox.setToolTipText(
         "Underground lighting will no longer flicker");
+    SearchUtils.addSearchMetadata(
+        generalPanelDisableUndergroundLightingCheckbox, "strobe", "strobing");
     // TODO: should introduce lighting flicker interval reduction as an option
 
     ButtonGroup ranChatEffectButtonGroup = new ButtonGroup();
@@ -2125,6 +2314,32 @@ public class ConfigWindow {
         "When running the client from a console, chat messages in the console will reflect the colours they are in game");
     SearchUtils.addSearchMetadata(
         generalPanelColoredTextCheckbox, CommonMetadata.COLOURS.getText());
+
+    JPanel generalPanelLogsFolderPanel = new JPanel();
+    generalPanel.add(generalPanelLogsFolderPanel);
+    generalPanelLogsFolderPanel.setLayout(
+        new BoxLayout(generalPanelLogsFolderPanel, BoxLayout.X_AXIS));
+    generalPanelLogsFolderPanel.setPreferredSize(osScaleMul(new Dimension(0, 30)));
+    generalPanelLogsFolderPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    generalPanelLogsFolderPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, osScaleMul(9), 0));
+
+    JLabel logsDirectoryLabel =
+        new JLabel("Log files are stored within a folder in the RSC+ settings directory");
+    logsDirectoryLabel.setAlignmentY(isUsingFlatLAFTheme() ? 0.85f : 1f);
+    generalPanelLogsFolderPanel.add(logsDirectoryLabel);
+
+    generalPanelLogsFolderPanel.add(Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+
+    JButton logsDirectoryOpenButton =
+        addButton("Open", generalPanelLogsFolderPanel, Component.RIGHT_ALIGNMENT);
+    logsDirectoryOpenButton.setAlignmentY(isUsingFlatLAFTheme() ? 0.75f : 0.8f);
+    logsDirectoryOpenButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.Dir.LOGS));
+          }
+        });
 
     // UI Settings
     addSettingsHeader(generalPanel, "UI settings");
@@ -2592,9 +2807,34 @@ public class ConfigWindow {
 
     addSettingsHeader(audioPanel, "Audio settings");
 
+    JPanel audioPanelEnableMusicPanel = new JPanel();
+    audioPanel.add(audioPanelEnableMusicPanel);
+    audioPanelEnableMusicPanel.setLayout(
+        new BoxLayout(audioPanelEnableMusicPanel, BoxLayout.X_AXIS));
+    audioPanelEnableMusicPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+    String musicPackTooltip =
+        "Drag the music pack into the \"mods\" folder and restart the client (no need to unzip)";
+
     audioPanelEnableMusicCheckbox =
-        addCheckbox("Enable Music (Must have music pack installed)", audioPanel);
-    audioPanelEnableMusicCheckbox.setToolTipText("Enable Music (Must have music pack installed)");
+        addCheckbox("Enable Music (Must have a music pack installed)", audioPanelEnableMusicPanel);
+    audioPanelEnableMusicCheckbox.setToolTipText(musicPackTooltip);
+
+    if (Util.isUsingFlatLAFTheme()) {
+      audioPanelEnableMusicPanel.add(Box.createRigidArea(osScaleMul(new Dimension(4, 0))));
+    }
+
+    JButton audioPanelMusicFolderButton =
+        addButton("Open folder", audioPanelEnableMusicPanel, Component.RIGHT_ALIGNMENT);
+    audioPanelMusicFolderButton.setAlignmentY(0.7f);
+    audioPanelMusicFolderButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.Dir.MODS));
+          }
+        });
+    audioPanelMusicFolderButton.setToolTipText(musicPackTooltip);
 
     JPanel audioPanelSfxVolumePanel = new JPanel();
     audioPanel.add(audioPanelSfxVolumePanel);
@@ -3157,13 +3397,39 @@ public class ConfigWindow {
     importPanel.setLayout(new BoxLayout(importPanel, BoxLayout.X_AXIS));
     importPanel.setPreferredSize(osScaleMul(new Dimension(0, 37)));
     importPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-    importPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, osScaleMul(10), 0));
+    importPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, osScaleMul(3), 0));
 
     importPanel.add(bankImportButton);
     bankPanelImportLabel = new JLabel(" ");
     bankPanelImportLabel.setAlignmentY(0.7f);
     bankPanelImportLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, osScaleMul(7), 0));
     importPanel.add(bankPanelImportLabel);
+
+    JPanel bankPanelBankFolderPanel = new JPanel();
+    bankPanel.add(bankPanelBankFolderPanel);
+    bankPanelBankFolderPanel.setLayout(new BoxLayout(bankPanelBankFolderPanel, BoxLayout.X_AXIS));
+    bankPanelBankFolderPanel.setPreferredSize(osScaleMul(new Dimension(0, 37)));
+    bankPanelBankFolderPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+    JLabel bankDirectoryLabel =
+        new JLabel("Bank files are stored within a folder in the RSC+ settings directory");
+    bankDirectoryLabel.setAlignmentY(isUsingFlatLAFTheme() ? 0.85f : 1f);
+    bankDirectoryLabel.setFont(
+        bankDirectoryLabel.getFont().deriveFont(Font.PLAIN, osScaleMul(13f)));
+    bankPanelBankFolderPanel.add(bankDirectoryLabel);
+
+    bankPanelBankFolderPanel.add(Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+
+    JButton bankDirectoryOpenButton =
+        addButton("Open", bankPanelBankFolderPanel, Component.RIGHT_ALIGNMENT);
+    bankDirectoryOpenButton.setAlignmentY(isUsingFlatLAFTheme() ? 0.75f : 0.8f);
+    bankDirectoryOpenButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.Dir.BANK));
+          }
+        });
 
     addPanelBottomGlue(bankPanel);
 
@@ -3581,6 +3847,34 @@ public class ConfigWindow {
                 osScaleMul(10), osScaleMul(5)));
     streamingPanelSpeedrunPanel.add(speedrunnerHowToSTOPSPEEDRUNNINGGGGExplanation);
     SearchUtils.skipSearchText(speedrunnerHowToSTOPSPEEDRUNNINGGGGExplanation);
+
+    JPanel streamingPanelSpeedrunnerFolderPanel = new JPanel();
+    streamingPanel.add(streamingPanelSpeedrunnerFolderPanel);
+    streamingPanelSpeedrunnerFolderPanel.setLayout(
+        new BoxLayout(streamingPanelSpeedrunnerFolderPanel, BoxLayout.X_AXIS));
+    streamingPanelSpeedrunnerFolderPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    streamingPanelSpeedrunnerFolderPanel.setBorder(
+        BorderFactory.createEmptyBorder(osScaleMul(4), 0, 0, 0));
+
+    JLabel speedrunnerFolderLabel =
+        new JLabel("Speedrunner data is stored within a folder in the RSC+ settings directory");
+    speedrunnerFolderLabel.setAlignmentY(0.8f);
+    speedrunnerFolderLabel.setFont(
+        speedrunnerFolderLabel.getFont().deriveFont(Font.PLAIN, osScaleMul(13f)));
+    streamingPanelSpeedrunnerFolderPanel.add(speedrunnerFolderLabel);
+
+    streamingPanelSpeedrunnerFolderPanel.add(Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+
+    JButton streamingPanelSpeedrunnerFolderButton =
+        addButton("Open folder", streamingPanelSpeedrunnerFolderPanel, Component.RIGHT_ALIGNMENT);
+    streamingPanelSpeedrunnerFolderButton.setAlignmentY(0.7f);
+    streamingPanelSpeedrunnerFolderButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.Dir.SPEEDRUN));
+          }
+        });
 
     /* shame to write all this code and then not need it...
     JPanel streamingPanelSpeedRunnerNamePanel = new JPanel();
@@ -4015,6 +4309,87 @@ public class ConfigWindow {
 
     addSettingsHeader(replayPanel, "Recording settings");
 
+    float replayButtonAlignment = isUsingFlatLAFTheme() ? 0.75f : 0.8f;
+    float replayLabelAlignment = isUsingFlatLAFTheme() ? 0.85f : 0.9f;
+    int replayPathTextHeight = isUsingFlatLAFTheme() ? 32 : 37;
+
+    /// Replay storage path
+
+    JPanel replayPanelReplayStoragePathTextFieldPanel = new JPanel();
+    replayPanel.add(replayPanelReplayStoragePathTextFieldPanel);
+    replayPanelReplayStoragePathTextFieldPanel.setLayout(
+        new BoxLayout(replayPanelReplayStoragePathTextFieldPanel, BoxLayout.X_AXIS));
+    replayPanelReplayStoragePathTextFieldPanel.setPreferredSize(
+        osScaleMul(new Dimension(0, replayPathTextHeight)));
+    replayPanelReplayStoragePathTextFieldPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    replayPanelReplayStoragePathTextFieldPanel.setBorder(
+        BorderFactory.createEmptyBorder(0, 0, osScaleMul(9), 0));
+
+    JLabel replayPanelReplayStoragePathTextFieldLabel = new JLabel("Save replays to: ");
+    replayPanelReplayStoragePathTextFieldLabel.setToolTipText(
+        "Location where your replays will be stored");
+    replayPanelReplayStoragePathTextFieldPanel.add(replayPanelReplayStoragePathTextFieldLabel);
+    replayPanelReplayStoragePathTextFieldLabel.setAlignmentY(replayLabelAlignment);
+
+    replayPanelReplayStoragePathTextField = new JTextField();
+    replayPanelReplayStoragePathTextFieldPanel.add(replayPanelReplayStoragePathTextField);
+    replayPanelReplayStoragePathTextField.setMinimumSize(osScaleMul(new Dimension(100, 28)));
+    replayPanelReplayStoragePathTextField.setMaximumSize(
+        new Dimension(Short.MAX_VALUE, osScaleMul(28)));
+    replayPanelReplayStoragePathTextField.setAlignmentY(0.75f);
+    replayPanelReplayStoragePathTextField.setToolTipText(
+        "To restore the default location, delete the value and apply settings");
+
+    if (Util.isUsingFlatLAFTheme()) {
+      replayPanelReplayStoragePathTextFieldPanel.add(
+          Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    File replayStorageDir = new File(Settings.REPLAY_STORAGE_PATH.get("custom"));
+    JFileChooser replayStorageDirChooser = new JFileChooser(replayStorageDir);
+    replayStorageDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+
+    JButton replayPanelReplayStoragePathSetDirButton =
+        addButton("Set", replayPanelReplayStoragePathTextFieldPanel, Component.RIGHT_ALIGNMENT);
+    replayPanelReplayStoragePathSetDirButton.setAlignmentY(replayButtonAlignment);
+    replayPanelReplayStoragePathSetDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            int choice = replayStorageDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
+            if (choice == JFileChooser.APPROVE_OPTION) {
+              File replayStorageDir = replayStorageDirChooser.getSelectedFile();
+              if (validateChosenDirectory(replayStorageDir)) {
+                reindexSearch(
+                    () -> {
+                      Settings.REPLAY_STORAGE_PATH.put("custom", replayStorageDir.toString());
+                      replayStorageDirChooser.setCurrentDirectory(replayStorageDir);
+                      Settings.save();
+                      synchronizeGuiValues();
+                    });
+              }
+            }
+          }
+        });
+
+    if (Util.isUsingFlatLAFTheme()) {
+      replayPanelReplayStoragePathTextFieldPanel.add(
+          Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    JButton replayPanelReplayStoragePathOpenDirButton =
+        addButton("Open", replayPanelReplayStoragePathTextFieldPanel, Component.RIGHT_ALIGNMENT);
+    replayPanelReplayStoragePathOpenDirButton.setAlignmentY(replayButtonAlignment);
+    replayPanelReplayStoragePathOpenDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            Util.openDirectory(new File(Settings.REPLAY_STORAGE_PATH.get("custom")));
+          }
+        });
+
+    ///
+
     replayPanelRecordAutomaticallyCheckbox =
         addCheckbox("Record your play sessions by default", replayPanel);
     replayPanelRecordAutomaticallyCheckbox.setToolTipText(
@@ -4059,31 +4434,87 @@ public class ConfigWindow {
 
     addSettingsHeader(replayPanel, "Replay Queue Window");
 
+    /// Replay folder location
+
     int replayTextHeight = isUsingFlatLAFTheme() ? 32 : 37;
 
-    JPanel replayPanelReplayFolderBasePathTextFieldPanel = new JPanel();
-    replayPanel.add(replayPanelReplayFolderBasePathTextFieldPanel);
-    replayPanelReplayFolderBasePathTextFieldPanel.setLayout(
-        new BoxLayout(replayPanelReplayFolderBasePathTextFieldPanel, BoxLayout.X_AXIS));
-    replayPanelReplayFolderBasePathTextFieldPanel.setPreferredSize(
+    JPanel replayPanelReplayBasePathTextFieldPanel = new JPanel();
+    replayPanel.add(replayPanelReplayBasePathTextFieldPanel);
+    replayPanelReplayBasePathTextFieldPanel.setLayout(
+        new BoxLayout(replayPanelReplayBasePathTextFieldPanel, BoxLayout.X_AXIS));
+    replayPanelReplayBasePathTextFieldPanel.setPreferredSize(
         osScaleMul(new Dimension(0, replayTextHeight)));
-    replayPanelReplayFolderBasePathTextFieldPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
-    replayPanelReplayFolderBasePathTextFieldPanel.setBorder(
+    replayPanelReplayBasePathTextFieldPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+    replayPanelReplayBasePathTextFieldPanel.setBorder(
         BorderFactory.createEmptyBorder(0, 0, osScaleMul(9), 0));
 
-    JLabel replayPanelReplayFolderBasePathTextFieldLabel = new JLabel("Replay Folder Location: ");
-    replayPanelReplayFolderBasePathTextFieldLabel.setToolTipText(
-        "Any string of characters you enter into this field will be removed from the Folder Path column in the Replay Queue window.");
-    replayPanelReplayFolderBasePathTextFieldPanel.add(
-        replayPanelReplayFolderBasePathTextFieldLabel);
-    replayPanelReplayFolderBasePathTextFieldLabel.setAlignmentY(0.9f);
+    JLabel replayPanelReplayBasePathTextFieldLabel = new JLabel("Replay Folder Location: ");
+    replayPanelReplayBasePathTextFieldLabel.setToolTipText(
+        "Default location for the replay queue file chooser");
+    replayPanelReplayBasePathTextFieldPanel.add(replayPanelReplayBasePathTextFieldLabel);
+    replayPanelReplayBasePathTextFieldLabel.setAlignmentY(replayLabelAlignment);
 
-    replayPanelReplayFolderBasePathTextField = new JTextField();
-    replayPanelReplayFolderBasePathTextFieldPanel.add(replayPanelReplayFolderBasePathTextField);
-    replayPanelReplayFolderBasePathTextField.setMinimumSize(osScaleMul(new Dimension(100, 28)));
-    replayPanelReplayFolderBasePathTextField.setMaximumSize(
+    replayPanelReplayBasePathTextField = new JTextField();
+    replayPanelReplayBasePathTextFieldPanel.add(replayPanelReplayBasePathTextField);
+    replayPanelReplayBasePathTextField.setMinimumSize(osScaleMul(new Dimension(100, 28)));
+    replayPanelReplayBasePathTextField.setMaximumSize(
         new Dimension(Short.MAX_VALUE, osScaleMul(28)));
-    replayPanelReplayFolderBasePathTextField.setAlignmentY(0.75f);
+    replayPanelReplayBasePathTextField.setAlignmentY(0.75f);
+    replayPanelReplayBasePathTextField.setToolTipText(
+        "Any string of characters you enter into this field will be removed from the Folder Path column in the Replay Queue window.");
+
+    if (Util.isUsingFlatLAFTheme()) {
+      replayPanelReplayBasePathTextFieldPanel.add(
+          Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    File replayBaseDir = new File(Settings.REPLAY_BASE_PATH.get("custom"));
+    JFileChooser replayBaseDirChooser = new JFileChooser(replayBaseDir);
+    replayBaseDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+
+    JButton replayPanelReplayBasePathSetDirButton =
+        addButton("Set", replayPanelReplayBasePathTextFieldPanel, Component.RIGHT_ALIGNMENT);
+    replayPanelReplayBasePathSetDirButton.setAlignmentY(replayButtonAlignment);
+    replayPanelReplayBasePathSetDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            int choice = replayBaseDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
+            if (choice == JFileChooser.APPROVE_OPTION) {
+              File replayBaseDir = replayBaseDirChooser.getSelectedFile();
+              if (validateChosenDirectory(replayBaseDir)) {
+                reindexSearch(
+                    () -> {
+                      Settings.REPLAY_BASE_PATH.put("custom", replayBaseDir.toString());
+                      replayBaseDirChooser.setCurrentDirectory(replayBaseDir);
+                      Settings.save();
+                      synchronizeGuiValues();
+                    });
+              }
+            }
+          }
+        });
+
+    if (Util.isUsingFlatLAFTheme()) {
+      replayPanelReplayBasePathTextFieldPanel.add(
+          Box.createRigidArea(osScaleMul(new Dimension(6, 0))));
+    }
+
+    JButton replayPanelReplayBasePathOpenDirButton =
+        addButton("Open", replayPanelReplayBasePathTextFieldPanel, Component.RIGHT_ALIGNMENT);
+    replayPanelReplayBasePathOpenDirButton.setAlignmentY(replayButtonAlignment);
+    replayPanelReplayBasePathOpenDirButton.addActionListener(
+        new ActionListener() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            String customReplayBaseDir = Settings.REPLAY_BASE_PATH.get("custom");
+            if (!("".equals(customReplayBaseDir))) {
+              Util.openDirectory(new File(customReplayBaseDir));
+            }
+          }
+        });
+
+    ////
 
     JPanel replayPanelDateFormatTextFieldPanel = new JPanel();
     replayPanel.add(replayPanelDateFormatTextFieldPanel);
@@ -4099,7 +4530,7 @@ public class ConfigWindow {
     replayPanelDateFormatTextFieldLabel.setToolTipText(
         "This is the date string pattern that you personally prefer. If you're not sure what your options are, check https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html");
     replayPanelDateFormatTextFieldPanel.add(replayPanelDateFormatTextFieldLabel);
-    replayPanelDateFormatTextFieldLabel.setAlignmentY(0.9f);
+    replayPanelDateFormatTextFieldLabel.setAlignmentY(replayLabelAlignment);
 
     replayPanelDateFormatTextField = new JTextField();
     replayPanelDateFormatTextFieldPanel.add(replayPanelDateFormatTextField);
@@ -4277,9 +4708,19 @@ public class ConfigWindow {
     addSettingsHeaderCentered(worldListPanel, "World List");
 
     JLabel spacingLabel = new JLabel("");
-    spacingLabel.setBorder(BorderFactory.createEmptyBorder(osScaleMul(15), 0, 0, 0));
+    spacingLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, osScaleMul(5), 0));
     worldListPanel.add(spacingLabel);
     SearchUtils.setUnsearchable(spacingLabel);
+
+    addSettingsHeaderLabel(
+        worldListPanel,
+        "<html><b>" + "Drag & drop world .ini files over this text to import them" + "</b></html>",
+        true);
+
+    JLabel spacingLabel2 = new JLabel("");
+    spacingLabel2.setBorder(BorderFactory.createEmptyBorder(osScaleMul(15), 0, 0, 0));
+    worldListPanel.add(spacingLabel2);
+    SearchUtils.setUnsearchable(spacingLabel2);
 
     for (int i = 1; i <= Settings.WORLDS_TO_DISPLAY; i++) {
       addWorldFields(i);
@@ -4454,6 +4895,33 @@ public class ConfigWindow {
     indexSearch();
   }
 
+  /**
+   * Validate whether a provided directory can be written to
+   *
+   * @param dir {@link File} instance for the provided directory
+   * @return {@code boolean} value indicating whether the provided directory was valid
+   */
+  private boolean validateChosenDirectory(File dir) {
+    if (!Files.isWritable(dir.toPath())) {
+      String dirPermissionsErrorMessage =
+          "RSCPlus is unable to create files in the folder you have selected.<br/>"
+              + "<br/>"
+              + "Please select a different location.";
+      JPanel dirPermissionsErrorPanel = Util.createOptionMessagePanel(dirPermissionsErrorMessage);
+
+      JOptionPane.showMessageDialog(
+          Launcher.getConfigWindow().frame,
+          dirPermissionsErrorPanel,
+          "RSCPlus",
+          JOptionPane.ERROR_MESSAGE,
+          Launcher.scaled_icon_warn);
+
+      return false;
+    }
+
+    return true;
+  }
+
   /** Resets the tooltip listener state */
   private void resetToolTipListener() {
     toolTipTextString = " ";
@@ -4490,22 +4958,6 @@ public class ConfigWindow {
     public String getText() {
       return text;
     }
-  }
-
-  /**
-   * Given a {@link ConfigTab} object, get the tab index
-   *
-   * @param configTab {@link ConfigTab} for which to get the index
-   * @return Tab index for the ConfigTab
-   */
-  private int getTabIndex(ConfigTab configTab) {
-    for (int i = 0; i < tabbedPane.getTabCount(); i++) {
-      if (tabbedPane.getTitleAt(i).equals(configTab.getLabel())) {
-        return i;
-      }
-    }
-
-    return -1;
   }
 
   /**
@@ -4781,7 +5233,7 @@ public class ConfigWindow {
               .filter(SearchItem::isSearchable)
               .count();
 
-      int tabIndex = getTabIndex(configTab);
+      int tabIndex = ConfigTab.getTabIndex(configTab);
 
       // This would only happen if a developer forgets to set a tab title when creating a new tab
       if (tabIndex != -1) {
@@ -4869,7 +5321,8 @@ public class ConfigWindow {
     if (firstVisibleSearchItemOptional.isPresent()) {
       SearchItem firstVisibleSearchItem = firstVisibleSearchItemOptional.get();
 
-      int firstVisibleSearchItemTabIndex = getTabIndex(firstVisibleSearchItem.getConfigTab());
+      int firstVisibleSearchItemTabIndex =
+          ConfigTab.getTabIndex(firstVisibleSearchItem.getConfigTab());
 
       // This would only happen if a developer forgets to set a tab title when creating a new tab
       // Even so, we don't want the game to crash
@@ -5432,6 +5885,8 @@ public class ConfigWindow {
     generalPanelLimitFPSSpinner.setValue(Settings.FPS_LIMIT.get(Settings.currentProfile));
     generalPanelAutoScreenshotCheckbox.setSelected(
         Settings.AUTO_SCREENSHOT.get(Settings.currentProfile));
+    generalPanelScreenshotsDirTextField.setText(
+        Settings.sanitizeDirTextValue(Settings.SCREENSHOTS_STORAGE_PATH.get("custom")));
     generalPanelRS2HDSkyCheckbox.setSelected(Settings.RS2HD_SKY.get(Settings.currentProfile));
     generalPanelCustomSkyboxOverworldCheckbox.setSelected(
         Settings.CUSTOM_SKYBOX_OVERWORLD_ENABLED.get(Settings.currentProfile));
@@ -5602,9 +6057,8 @@ public class ConfigWindow {
     generalPanelDebugModeCheckbox.setSelected(Settings.DEBUG.get(Settings.currentProfile));
     generalPanelExceptionHandlerCheckbox.setSelected(
         Settings.EXCEPTION_HANDLER.get(Settings.currentProfile));
-    highlightedItemsTextField.setText(
-        Util.joinAsString(",", Settings.HIGHLIGHTED_ITEMS.get("custom")));
-    blockedItemsTextField.setText(Util.joinAsString(",", Settings.BLOCKED_ITEMS.get("custom")));
+    highlightedItemsTextField.setText(String.join(",", Settings.HIGHLIGHTED_ITEMS.get("custom")));
+    blockedItemsTextField.setText(String.join(",", Settings.BLOCKED_ITEMS.get("custom")));
     itemHighlightColour =
         Util.intToColor(Settings.ITEM_HIGHLIGHT_COLOUR.get(Settings.currentProfile));
     overlayPanelHighlightRightClickCheckbox.setSelected(
@@ -5713,7 +6167,7 @@ public class ConfigWindow {
     notificationPanelPMNotifsCheckbox.setSelected(
         Settings.PM_NOTIFICATIONS.get(Settings.currentProfile));
     notificationPanelPMDenyListTextField.setText(
-        Util.joinAsString(",", Settings.PM_DENYLIST.get("custom")));
+        String.join(",", Settings.PM_DENYLIST.get("custom")));
     notificationPanelTradeNotifsCheckbox.setSelected(
         Settings.TRADE_NOTIFICATIONS.get(Settings.currentProfile));
     notificationPanelDuelNotifsCheckbox.setSelected(
@@ -5746,10 +6200,9 @@ public class ConfigWindow {
         !Settings.SOUND_NOTIFS_ALWAYS.get(Settings.currentProfile));
     notificationPanelNotifSoundAnyFocusButton.setSelected(
         Settings.SOUND_NOTIFS_ALWAYS.get(Settings.currentProfile));
-    importantMessagesTextField.setText(
-        Util.joinAsString(",", Settings.IMPORTANT_MESSAGES.get("custom")));
+    importantMessagesTextField.setText(String.join(",", Settings.IMPORTANT_MESSAGES.get("custom")));
     importantSadMessagesTextField.setText(
-        Util.joinAsString(",", Settings.IMPORTANT_SAD_MESSAGES.get("custom")));
+        String.join(",", Settings.IMPORTANT_SAD_MESSAGES.get("custom")));
     notificationPanelMuteImportantMessageSoundsCheckbox.setSelected(
         Settings.MUTE_IMPORTANT_MESSAGE_SOUNDS.get(Settings.currentProfile));
 
@@ -5774,6 +6227,8 @@ public class ConfigWindow {
     // streamingPanelSpeedrunnerUsernameTextField.setText(Settings.SPEEDRUNNER_USERNAME.get(Settings.currentProfile));
 
     // Replay tab
+    replayPanelReplayStoragePathTextField.setText(
+        Settings.sanitizeDirTextValue(Settings.REPLAY_STORAGE_PATH.get("custom")));
     replayPanelRecordAutomaticallyCheckbox.setSelected(
         Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile));
     replayPanelParseOpcodesCheckbox.setSelected(
@@ -5790,7 +6245,8 @@ public class ConfigWindow {
     replayPanelTriggerAlertsReplayCheckbox.setSelected(
         Settings.TRIGGER_ALERTS_REPLAY.get(Settings.currentProfile));
     replayPanelDateFormatTextField.setText(Settings.PREFERRED_DATE_FORMAT.get("custom"));
-    replayPanelReplayFolderBasePathTextField.setText(Settings.REPLAY_BASE_PATH.get("custom"));
+    replayPanelReplayBasePathTextField.setText(
+        Settings.sanitizeDirTextValue(Settings.REPLAY_BASE_PATH.get("custom")));
     replayPanelShowWorldColumnCheckbox.setSelected(
         Settings.SHOW_WORLD_COLUMN.get(Settings.currentProfile));
     replayPanelShowConversionSettingsCheckbox.setSelected(
@@ -5955,6 +6411,10 @@ public class ConfigWindow {
         Settings.currentProfile, generalPanelTrackpadRotationSlider.getValue());
     Settings.AUTO_SCREENSHOT.put(
         Settings.currentProfile, generalPanelAutoScreenshotCheckbox.isSelected());
+    Settings.SCREENSHOTS_STORAGE_PATH.put(
+        Settings.currentProfile,
+        Settings.validateCustomDir(
+            generalPanelScreenshotsDirTextField.getText(), Settings.Dir.SCREENSHOT));
     Settings.RS2HD_SKY.put(Settings.currentProfile, generalPanelRS2HDSkyCheckbox.isSelected());
     Settings.CUSTOM_SKYBOX_OVERWORLD_ENABLED.put(
         Settings.currentProfile, generalPanelCustomSkyboxOverworldCheckbox.isSelected());
@@ -6233,6 +6693,10 @@ public class ConfigWindow {
     //    Settings.currentProfile, streamingPanelSpeedrunnerUsernameTextField.getText());
 
     // Replay
+    Settings.REPLAY_STORAGE_PATH.put(
+        Settings.currentProfile,
+        Settings.validateCustomDir(
+            replayPanelReplayStoragePathTextField.getText(), Settings.Dir.REPLAY));
     Settings.RECORD_AUTOMATICALLY.put(
         Settings.currentProfile, replayPanelRecordAutomaticallyCheckbox.isSelected());
     Settings.PARSE_OPCODES.put(
@@ -6250,7 +6714,8 @@ public class ConfigWindow {
     Settings.TRIGGER_ALERTS_REPLAY.put(
         Settings.currentProfile, replayPanelTriggerAlertsReplayCheckbox.isSelected());
     Settings.REPLAY_BASE_PATH.put(
-        Settings.currentProfile, replayPanelReplayFolderBasePathTextField.getText());
+        Settings.currentProfile,
+        Settings.validateCustomDir(replayPanelReplayBasePathTextField.getText(), ""));
     Settings.PREFERRED_DATE_FORMAT.put(
         Settings.currentProfile, replayPanelDateFormatTextField.getText());
     Settings.SHOW_WORLD_COLUMN.put(
@@ -6599,7 +7064,7 @@ public class ConfigWindow {
     worldListSpacingLabels.put(i, new JLabel(""));
     worldListSpacingLabels
         .get(i)
-        .setBorder(BorderFactory.createEmptyBorder(osScaleMul(30), 0, 0, 0));
+        .setBorder(BorderFactory.createEmptyBorder(osScaleMul(20), 0, 0, 0));
     worldListPanel.add(worldListSpacingLabels.get(i));
 
     //// create world
@@ -6609,37 +7074,40 @@ public class ConfigWindow {
   }
 
   private void addAddWorldButton() {
-    JButton addWorldButton = new JButton("Add New World");
+    addWorldButton = new JButton("Add New World");
     addWorldButton.setAlignmentX(JButton.CENTER_ALIGNMENT);
     addWorldButton.addActionListener(
         new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
-            worldListPanel.remove(addWorldButton);
-            Component verticalGlue =
-                Arrays.stream(worldListPanel.getComponents())
-                    .filter(
-                        c -> c.getName() != null && c.getName().equals("world_listPanelBottomGlue"))
-                    .findFirst()
-                    .orElse(null);
-            if (verticalGlue != null) {
-              worldListPanel.remove(verticalGlue);
-            }
-            ++Settings.WORLDS_TO_DISPLAY;
-            // Reindex search to account for the altered UI
-            reindexSearch(
-                () -> {
-                  synchronizeWorldTab();
-                  addAddWorldButton();
-                  if (verticalGlue != null) {
-                    worldListPanel.add(verticalGlue);
-                  }
-                });
+            addWorldAction();
           }
         });
     worldListPanel.add(addWorldButton);
     worldListPanel.revalidate();
     worldListPanel.repaint();
+  }
+
+  private void addWorldAction() {
+    worldListPanel.remove(addWorldButton);
+    Component verticalGlue =
+        Arrays.stream(worldListPanel.getComponents())
+            .filter(c -> c.getName() != null && c.getName().equals("world_listPanelBottomGlue"))
+            .findFirst()
+            .orElse(null);
+    if (verticalGlue != null) {
+      worldListPanel.remove(verticalGlue);
+    }
+    ++Settings.WORLDS_TO_DISPLAY;
+    // Reindex search to account for the altered UI
+    reindexSearch(
+        () -> {
+          synchronizeWorldTab();
+          addAddWorldButton();
+          if (verticalGlue != null) {
+            worldListPanel.add(verticalGlue);
+          }
+        });
   }
 
   // adds or removes world list text fields & fills them with their values

--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -1654,19 +1654,7 @@ public class ConfigWindow {
         new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
-            int choice = screenshotDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
-            if (choice == JFileChooser.APPROVE_OPTION) {
-              File screenshotsDir = screenshotDirChooser.getSelectedFile();
-              if (validateChosenDirectory(screenshotsDir)) {
-                reindexSearch(
-                    () -> {
-                      Settings.SCREENSHOTS_STORAGE_PATH.put("custom", screenshotsDir.toString());
-                      screenshotDirChooser.setCurrentDirectory(screenshotsDir);
-                      Settings.save();
-                      synchronizeGuiValues();
-                    });
-              }
-            }
+            customDirSetAction(screenshotDirChooser, Settings.SCREENSHOTS_STORAGE_PATH);
           }
         });
 
@@ -4356,19 +4344,7 @@ public class ConfigWindow {
         new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
-            int choice = replayStorageDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
-            if (choice == JFileChooser.APPROVE_OPTION) {
-              File replayStorageDir = replayStorageDirChooser.getSelectedFile();
-              if (validateChosenDirectory(replayStorageDir)) {
-                reindexSearch(
-                    () -> {
-                      Settings.REPLAY_STORAGE_PATH.put("custom", replayStorageDir.toString());
-                      replayStorageDirChooser.setCurrentDirectory(replayStorageDir);
-                      Settings.save();
-                      synchronizeGuiValues();
-                    });
-              }
-            }
+            customDirSetAction(replayStorageDirChooser, Settings.REPLAY_STORAGE_PATH);
           }
         });
 
@@ -4479,19 +4455,7 @@ public class ConfigWindow {
         new ActionListener() {
           @Override
           public void actionPerformed(ActionEvent e) {
-            int choice = replayBaseDirChooser.showOpenDialog(Launcher.getConfigWindow().frame);
-            if (choice == JFileChooser.APPROVE_OPTION) {
-              File replayBaseDir = replayBaseDirChooser.getSelectedFile();
-              if (validateChosenDirectory(replayBaseDir)) {
-                reindexSearch(
-                    () -> {
-                      Settings.REPLAY_BASE_PATH.put("custom", replayBaseDir.toString());
-                      replayBaseDirChooser.setCurrentDirectory(replayBaseDir);
-                      Settings.save();
-                      synchronizeGuiValues();
-                    });
-              }
-            }
+            customDirSetAction(replayBaseDirChooser, Settings.REPLAY_BASE_PATH);
           }
         });
 
@@ -4896,10 +4860,35 @@ public class ConfigWindow {
   }
 
   /**
-   * Validate whether a provided directory can be written to
+   * Performs the action when a "set" button is clicked for a setting dealing with choosing a custom
+   * directory such as screenshot storage
+   *
+   * @param fileChooser {@link JFileChooser} instance to work with
+   * @param customDirSetting {@link Settings} hashmap for the custom directory
+   */
+  private void customDirSetAction(
+      JFileChooser fileChooser, HashMap<String, String> customDirSetting) {
+    int choice = fileChooser.showOpenDialog(Launcher.getConfigWindow().frame);
+    if (choice == JFileChooser.APPROVE_OPTION) {
+      File chosenDir = fileChooser.getSelectedFile();
+      if (validateChosenDirectory(chosenDir)) {
+        reindexSearch(
+            () -> {
+              String filePath = chosenDir.getAbsolutePath() + File.separator;
+              customDirSetting.put("custom", filePath);
+              fileChooser.setCurrentDirectory(chosenDir);
+              Settings.save();
+              synchronizeGuiValues();
+            });
+      }
+    }
+  }
+
+  /**
+   * Validate whether a provided directory can be written to, displaying an error modal if not
    *
    * @param dir {@link File} instance for the provided directory
-   * @return {@code boolean} value indicating whether the provided directory was valid
+   * @return {@code boolean} value indicating whether the provided directory is writeable
    */
   private boolean validateChosenDirectory(File dir) {
     if (!Files.isWritable(dir.toPath())) {
@@ -5885,8 +5874,7 @@ public class ConfigWindow {
     generalPanelLimitFPSSpinner.setValue(Settings.FPS_LIMIT.get(Settings.currentProfile));
     generalPanelAutoScreenshotCheckbox.setSelected(
         Settings.AUTO_SCREENSHOT.get(Settings.currentProfile));
-    generalPanelScreenshotsDirTextField.setText(
-        Settings.sanitizeDirTextValue(Settings.SCREENSHOTS_STORAGE_PATH.get("custom")));
+    generalPanelScreenshotsDirTextField.setText(Settings.SCREENSHOTS_STORAGE_PATH.get("custom"));
     generalPanelRS2HDSkyCheckbox.setSelected(Settings.RS2HD_SKY.get(Settings.currentProfile));
     generalPanelCustomSkyboxOverworldCheckbox.setSelected(
         Settings.CUSTOM_SKYBOX_OVERWORLD_ENABLED.get(Settings.currentProfile));
@@ -6227,8 +6215,7 @@ public class ConfigWindow {
     // streamingPanelSpeedrunnerUsernameTextField.setText(Settings.SPEEDRUNNER_USERNAME.get(Settings.currentProfile));
 
     // Replay tab
-    replayPanelReplayStoragePathTextField.setText(
-        Settings.sanitizeDirTextValue(Settings.REPLAY_STORAGE_PATH.get("custom")));
+    replayPanelReplayStoragePathTextField.setText(Settings.REPLAY_STORAGE_PATH.get("custom"));
     replayPanelRecordAutomaticallyCheckbox.setSelected(
         Settings.RECORD_AUTOMATICALLY.get(Settings.currentProfile));
     replayPanelParseOpcodesCheckbox.setSelected(
@@ -6245,8 +6232,7 @@ public class ConfigWindow {
     replayPanelTriggerAlertsReplayCheckbox.setSelected(
         Settings.TRIGGER_ALERTS_REPLAY.get(Settings.currentProfile));
     replayPanelDateFormatTextField.setText(Settings.PREFERRED_DATE_FORMAT.get("custom"));
-    replayPanelReplayBasePathTextField.setText(
-        Settings.sanitizeDirTextValue(Settings.REPLAY_BASE_PATH.get("custom")));
+    replayPanelReplayBasePathTextField.setText(Settings.REPLAY_BASE_PATH.get("custom"));
     replayPanelShowWorldColumnCheckbox.setSelected(
         Settings.SHOW_WORLD_COLUMN.get(Settings.currentProfile));
     replayPanelShowConversionSettingsCheckbox.setSelected(

--- a/src/Client/FlatLaf/FlatDarkLaf.properties
+++ b/src/Client/FlatLaf/FlatDarkLaf.properties
@@ -1,6 +1,8 @@
 @background=#2a2e30
 @foreground=#dddddd
 
+@disabledForeground = shade(@foreground,50%)
+
 TabbedPane.background=#34383a
 TabbedPane.selectedBackground=#222222
 

--- a/src/Client/Logger.java
+++ b/src/Client/Logger.java
@@ -27,11 +27,14 @@ import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import org.fusesource.jansi.AnsiConsole;
 
 /** A simple logger */
 public class Logger {
+  private static final int MAX_LOG_FILES = 20;
   private static PrintWriter m_logWriter;
   private static int levelFixedWidth = 0;
   private static String m_uncoloredMessage = "";
@@ -62,10 +65,36 @@ public class Logger {
 
   public static void start() {
     AnsiConsole.systemInstall();
-    File file = new File(Settings.Dir.JAR + "/log.txt");
+
+    // Although we have a setting for the preferred date format, it is only
+    // loaded AFTER the logger is initialized, so we can't really use it.
+    // Additionally, log files are not nearly as user-facing as replay files.
+    String timeStamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+
+    File logFile = new File(Settings.Dir.LOGS + "/log_" + timeStamp + ".txt");
     try {
-      m_logWriter = new PrintWriter(new FileOutputStream(file));
+      m_logWriter = new PrintWriter(new FileOutputStream(logFile));
     } catch (Exception e) {
+      System.out.println("Failed to create log file");
+      e.printStackTrace();
+    }
+  }
+
+  /** Deletes all log files that exceed the MAX_LOG_FILES count */
+  public static void purgeOldestLogFiles() {
+    File logsDir = new File(Settings.Dir.LOGS);
+    File[] logFiles = logsDir.listFiles();
+    if (logFiles != null && logFiles.length > MAX_LOG_FILES) {
+      // Simpler than extracting date from file name
+      Arrays.sort(logFiles, Comparator.comparingLong(File::lastModified));
+      try {
+        for (int i = 0; i < logFiles.length - MAX_LOG_FILES; i++) {
+          logFiles[i].delete();
+        }
+      } catch (Exception e) {
+        Logger.Error("Failed to delete the oldest log file");
+        e.printStackTrace();
+      }
     }
   }
 

--- a/src/Client/Logger.java
+++ b/src/Client/Logger.java
@@ -35,6 +35,8 @@ import org.fusesource.jansi.AnsiConsole;
 /** A simple logger */
 public class Logger {
   private static final int MAX_LOG_FILES = 20;
+  private static final String LOG_FILE_PREFIX = "rscplus_";
+  private static final String LOG_FILE_EXTENSION = ".log";
   private static PrintWriter m_logWriter;
   private static int levelFixedWidth = 0;
   private static String m_uncoloredMessage = "";
@@ -71,7 +73,9 @@ public class Logger {
     // Additionally, log files are not nearly as user-facing as replay files.
     String timeStamp = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
 
-    File logFile = new File(Settings.Dir.LOGS + "/log_" + timeStamp + ".txt");
+    File logFile =
+        new File(
+            Settings.Dir.LOGS + File.separator + LOG_FILE_PREFIX + timeStamp + LOG_FILE_EXTENSION);
     try {
       m_logWriter = new PrintWriter(new FileOutputStream(logFile));
     } catch (Exception e) {
@@ -83,8 +87,22 @@ public class Logger {
   /** Deletes all log files that exceed the MAX_LOG_FILES count */
   public static void purgeOldestLogFiles() {
     File logsDir = new File(Settings.Dir.LOGS);
-    File[] logFiles = logsDir.listFiles();
-    if (logFiles != null && logFiles.length > MAX_LOG_FILES) {
+
+    File[] fileList = logsDir.listFiles();
+    if (fileList == null) {
+      return;
+    }
+
+    File[] logFiles =
+        Arrays.stream(fileList)
+            .filter(
+                f ->
+                    f.isFile()
+                        && f.getName().startsWith(LOG_FILE_PREFIX)
+                        && f.getName().endsWith(LOG_FILE_EXTENSION))
+            .toArray(File[]::new);
+
+    if (logFiles.length > MAX_LOG_FILES) {
       // Simpler than extracting date from file name
       Arrays.sort(logFiles, Comparator.comparingLong(File::lastModified));
       try {

--- a/src/Client/Logger.java
+++ b/src/Client/Logger.java
@@ -99,7 +99,11 @@ public class Logger {
                 f ->
                     f.isFile()
                         && f.getName().startsWith(LOG_FILE_PREFIX)
-                        && f.getName().endsWith(LOG_FILE_EXTENSION))
+                        && f.getName().endsWith(LOG_FILE_EXTENSION)
+                        && f.getName().length()
+                            == LOG_FILE_PREFIX.length()
+                                + LOG_FILE_EXTENSION.length()
+                                + "yyyy-MM-dd_HH-mm-ss".length())
             .toArray(File[]::new);
 
     if (logFiles.length > MAX_LOG_FILES) {

--- a/src/Client/NotificationsHandler.java
+++ b/src/Client/NotificationsHandler.java
@@ -205,7 +205,7 @@ public class NotificationsHandler {
      * So basically, if we're running windows, everything renders normally and looks great. If we aren't, we assume
      * everything breaks and revert to a simpler but compatible look
      */
-    if (System.getProperty("os.name").contains("Windows")) {
+    if (Util.isWindowsOS()) {
       // 1
       // Configure the frame to have rounded corners and to be transparent
       notificationFrame.setShape(
@@ -569,8 +569,7 @@ public class NotificationsHandler {
     final String sanitizedText =
         text.replaceAll("@...@", "").replaceAll("~...~", "").replaceAll("\\\\", "\\\\\\\\");
 
-    if (Settings.USE_SYSTEM_NOTIFICATIONS.get(Settings.currentProfile)
-        && !System.getProperty("os.name").contains("Windows")) {
+    if (Settings.USE_SYSTEM_NOTIFICATIONS.get(Settings.currentProfile) && !Util.isWindowsOS()) {
       if (!hasNotifySend) {
         Client.displayMessage(
             "@red@You have to install notify-send for native system notifications!",

--- a/src/Client/QueueWindow.java
+++ b/src/Client/QueueWindow.java
@@ -746,7 +746,7 @@ public class QueueWindow {
             if (!ReplayQueue.queue.get(row).renameTo(renamedFile)) {
               Logger.Warn(
                   "@|red Failed to rename row: |@" + ReplayQueue.queue.get(row).getAbsolutePath());
-              if (System.getProperty("os.name").contains("Windows")) {
+              if (Util.isWindowsOS()) {
                 if (afterEditValue.matches(".*[?%*:|\"<>]")) {
                   Logger.Warn(
                       String.format(
@@ -968,13 +968,13 @@ public class QueueWindow {
       String cellTextReplaced = cellText.replace(Settings.REPLAY_BASE_PATH.get("custom"), "");
 
       if (cellText.equals(cellTextReplaced)) {
-        if (System.getProperty("os.name").contains("Windows")) {
+        if (Util.isWindowsOS()) {
           cellText += "\\";
         } else {
           cellText += "/";
         }
       } else {
-        if (System.getProperty("os.name").contains("Windows")) {
+        if (Util.isWindowsOS()) {
           cellText = String.format(".\\%s\\", cellTextReplaced);
         } else {
           cellText = String.format("./%s/", cellTextReplaced);

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2596,7 +2596,12 @@ public class Settings {
       return path;
     }
 
-    return new File(path).getAbsolutePath();
+    if (Util.isWindowsOS()) {
+      String windowsPath = new File(path).getAbsolutePath();
+      return (windowsPath + (windowsPath.endsWith("\\") ? "" : "\\")).replaceAll("\\+", "\\");
+    }
+
+    return (path + (path.endsWith("/") ? "" : "/")).replaceAll("/+", "/");
   }
 
   /**
@@ -2859,23 +2864,26 @@ public class Settings {
    * @return String value of the provided directory if valid, or sanitized fallback if not
    */
   public static String validateCustomDir(String dir, String fallback) {
-    final String sanitizedFallback = sanitizeDirTextValue(fallback);
+    boolean returnFallback = false;
 
     if ("".equals(dir)) {
-      return sanitizedFallback;
+      returnFallback = true;
     }
 
     File dirFile = new File(dir);
-
     if (!(dirFile.exists())) {
-      return sanitizedFallback;
+      returnFallback = true;
     }
 
     if (!Files.isWritable(dirFile.toPath())) {
-      return sanitizedFallback;
+      returnFallback = true;
     }
 
-    return dir;
+    if (returnFallback) {
+      return sanitizeDirTextValue(fallback);
+    }
+
+    return sanitizeDirTextValue(dir);
   }
 
   /**

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -38,11 +38,14 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Properties;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 
 /** Manages storing, loading, and changing settings. */
 public class Settings {
@@ -53,8 +56,10 @@ public class Settings {
   public static boolean versionCheckRequired = true;
   public static int javaVersion = 0;
   public static final double VERSION_NUMBER = 20230818.180806;
-  public static boolean successfullyInitted = false;
-  public static boolean presetModified = false;
+
+  static String CONFIG_FILE = null;
+  static boolean successfullyInitted = false;
+  static boolean presetModified = false;
 
   /**
    * A time stamp corresponding to the current version of this source code. Used as a sophisticated
@@ -137,6 +142,7 @@ public class Settings {
       new HashMap<String, RanOverrideEffectType>();
   public static HashMap<String, Integer> RAN_EFFECT_TARGET_FPS = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> AUTO_SCREENSHOT = new HashMap<String, Boolean>();
+  public static HashMap<String, String> SCREENSHOTS_STORAGE_PATH = new HashMap<String, String>();
   public static HashMap<String, Boolean> RS2HD_SKY = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> CUSTOM_SKYBOX_OVERWORLD_ENABLED =
       new HashMap<String, Boolean>();
@@ -314,6 +320,7 @@ public class Settings {
   // public static HashMap<String, String> SPEEDRUNNER_USERNAME = new HashMap<String, String>();
 
   //// replay
+  public static HashMap<String, String> REPLAY_STORAGE_PATH = new HashMap<String, String>();
   public static HashMap<String, Boolean> RECORD_KB_MOUSE = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> PARSE_OPCODES = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> FAST_DISCONNECT = new HashMap<String, Boolean>();
@@ -347,7 +354,7 @@ public class Settings {
   public static HashMap<String, Boolean> JOYSTICK_ENABLED = new HashMap<String, Boolean>();
 
   //// no gui
-  public static HashMap<String, Integer> COMBAT_STYLE = new HashMap<String, Integer>();
+  public static HashMap<String, Integer> LAST_KNOWN_COMBAT_STYLE = new HashMap<String, Integer>();
   public static HashMap<String, Integer> WORLD = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> FIRST_TIME = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> UPDATE_CONFIRMATION = new HashMap<String, Boolean>();
@@ -911,6 +918,10 @@ public class Settings {
     AUTO_SCREENSHOT.put("all", true);
     AUTO_SCREENSHOT.put(
         "custom", getPropBoolean(props, "auto_screenshot", AUTO_SCREENSHOT.get("default")));
+
+    defineStaticPreset(
+        SCREENSHOTS_STORAGE_PATH,
+        getPropString(props, "screenshots_storage_path", sanitizeDirTextValue(Dir.SCREENSHOT)));
 
     RS2HD_SKY.put("vanilla", false);
     RS2HD_SKY.put("vanilla_resizable", false);
@@ -2214,6 +2225,10 @@ public class Settings {
         */
 
     //// replay
+    defineStaticPreset(
+        REPLAY_STORAGE_PATH,
+        getPropString(props, "replay_storage_path", sanitizeDirTextValue(Dir.REPLAY)));
+
     RECORD_KB_MOUSE.put("vanilla", false);
     RECORD_KB_MOUSE.put("vanilla_resizable", false);
     RECORD_KB_MOUSE.put("lite", false);
@@ -2371,7 +2386,9 @@ public class Settings {
         "custom", getPropBoolean(props, "joystick_enabled", JOYSTICK_ENABLED.get("default")));
 
     //// no gui
-    defineStaticPreset(COMBAT_STYLE, getPropInt(props, "combat_style", Client.COMBAT_AGGRESSIVE));
+    defineStaticPreset(
+        LAST_KNOWN_COMBAT_STYLE,
+        getPropInt(props, "last_known_combat_style", Client.COMBAT_AGGRESSIVE));
 
     defineStaticPreset(WORLD, getPropInt(props, "world", 1));
 
@@ -2388,92 +2405,9 @@ public class Settings {
     defineStaticPreset(
         DISASSEMBLE_DIRECTORY, getPropString(props, "disassemble_directory", "dump"));
 
-    // Sanitize settings
+    // Ensure current profile is set to custom whenever this is invoked
     if (!currentProfile.equals("custom")) {
       currentProfile = "custom";
-    }
-
-    if (CUSTOM_CLIENT_SIZE_X.get("custom") < 512) {
-      CUSTOM_CLIENT_SIZE_X.put("custom", 512);
-      save("custom");
-    }
-    if (CUSTOM_CLIENT_SIZE_Y.get("custom") < 346) {
-      CUSTOM_CLIENT_SIZE_Y.put("custom", 346);
-      save("custom");
-    }
-
-    if (INTEGER_SCALING_FACTOR.get("custom") < (int) Renderer.minScalar) {
-      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.minScalar);
-    } else if (INTEGER_SCALING_FACTOR.get("custom") > (int) Renderer.maxIntegerScalar) {
-      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.maxIntegerScalar);
-    }
-
-    if (BILINEAR_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
-      BILINEAR_SCALING_FACTOR.put("custom", Renderer.minScalar);
-    } else if (BILINEAR_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
-      BILINEAR_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
-    }
-
-    if (BICUBIC_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
-      BICUBIC_SCALING_FACTOR.put("custom", Renderer.minScalar);
-    } else if (BICUBIC_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
-      BICUBIC_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
-    }
-
-    if (WORLD.get("custom") < 0) {
-      WORLD.put("custom", 0);
-      save("custom");
-    } else if (WORLD.get("custom") > Settings.WORLDS_TO_DISPLAY) {
-      WORLD.put("custom", Settings.WORLDS_TO_DISPLAY);
-      save("custom");
-    }
-
-    if (SFX_VOLUME.get("custom") < 0) {
-      SFX_VOLUME.put("custom", 0);
-      save("custom");
-    } else if (SFX_VOLUME.get("custom") > 100) {
-      SFX_VOLUME.put("custom", 100);
-      save("custom");
-    }
-
-    if (VIEW_DISTANCE.get("custom") < 2300) {
-      VIEW_DISTANCE.put("custom", 2300);
-      save("custom");
-    } else if (VIEW_DISTANCE.get("custom") > 20000) {
-      VIEW_DISTANCE.put("custom", 20000);
-      save("custom");
-    }
-
-    if (TRACKPAD_ROTATION_SENSITIVITY.get("custom") < 0) {
-      TRACKPAD_ROTATION_SENSITIVITY.put("custom", 0);
-      save("custom");
-    } else if (TRACKPAD_ROTATION_SENSITIVITY.get("custom") > 16) {
-      TRACKPAD_ROTATION_SENSITIVITY.put("custom", 16);
-      save("custom");
-    }
-
-    if (COMBAT_STYLE.get("custom") < Client.COMBAT_CONTROLLED) {
-      COMBAT_STYLE.put("custom", Client.COMBAT_CONTROLLED);
-      save("custom");
-    } else if (COMBAT_STYLE.get("custom") > Client.COMBAT_DEFENSIVE) {
-      COMBAT_STYLE.put("custom", Client.COMBAT_DEFENSIVE);
-      save("custom");
-    }
-
-    if (NAME_PATCH_TYPE.get("custom") < 0) {
-      NAME_PATCH_TYPE.put("custom", 0);
-      save("custom");
-    } else if (NAME_PATCH_TYPE.get("custom") > 3) {
-      NAME_PATCH_TYPE.put("custom", 3);
-      save("custom");
-    }
-
-    if (FATIGUE_FIGURES.get("custom") < 1) {
-      FATIGUE_FIGURES.put("custom", 1);
-      save("custom");
-    } else if (FATIGUE_FIGURES.get("custom") > 7) {
-      FATIGUE_FIGURES.put("custom", 7);
-      save("custom");
     }
   }
 
@@ -2522,6 +2456,149 @@ public class Settings {
 
   /* * * * * * */
 
+  /** Detects and fixes invalid values for critically-important settings */
+  public static void sanitizeSettings() {
+    boolean foundInvalidSetting = false;
+
+    /* Check for migrated props */
+
+    Properties props = loadProps();
+
+    // Migrating users from their old global combat style to the
+    // new per-character combat style introduced in Oct 2023
+    if (props.get("combat_style") != null) {
+      LAST_KNOWN_COMBAT_STYLE.put("custom", Integer.parseInt((String) props.get("combat_style")));
+      foundInvalidSetting = true;
+    }
+
+    /* Check for invalid setting values */
+
+    String screenshotsStorageDir = SCREENSHOTS_STORAGE_PATH.get("custom");
+    String validatedScreenshotsStorageDir =
+        validateCustomDir(screenshotsStorageDir, Dir.SCREENSHOT);
+    if (!screenshotsStorageDir.equals(validatedScreenshotsStorageDir)) {
+      SCREENSHOTS_STORAGE_PATH.put("custom", validatedScreenshotsStorageDir);
+      foundInvalidSetting = true;
+    }
+
+    String replayStorageDir = REPLAY_STORAGE_PATH.get("custom");
+    String validatedReplayStorageDir = validateCustomDir(replayStorageDir, Dir.REPLAY);
+    if (!replayStorageDir.equals(validatedReplayStorageDir)) {
+      REPLAY_STORAGE_PATH.put("custom", validatedReplayStorageDir);
+      foundInvalidSetting = true;
+    }
+
+    String replayBaseDir = Settings.REPLAY_BASE_PATH.get("custom");
+    String validatedReplayBaseDir = validateCustomDir(replayBaseDir, "");
+    if (!replayBaseDir.equals(validatedReplayBaseDir)) {
+      REPLAY_BASE_PATH.put("custom", validatedReplayBaseDir);
+      foundInvalidSetting = true;
+    }
+
+    if (CUSTOM_CLIENT_SIZE_X.get("custom") < 512) {
+      CUSTOM_CLIENT_SIZE_X.put("custom", 512);
+      foundInvalidSetting = true;
+    }
+
+    if (CUSTOM_CLIENT_SIZE_Y.get("custom") < 346) {
+      CUSTOM_CLIENT_SIZE_Y.put("custom", 346);
+      foundInvalidSetting = true;
+    }
+
+    if (INTEGER_SCALING_FACTOR.get("custom") < (int) Renderer.minScalar) {
+      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.minScalar);
+      foundInvalidSetting = true;
+    } else if (INTEGER_SCALING_FACTOR.get("custom") > (int) Renderer.maxIntegerScalar) {
+      INTEGER_SCALING_FACTOR.put("custom", (int) Renderer.maxIntegerScalar);
+      foundInvalidSetting = true;
+    }
+
+    if (BILINEAR_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
+      BILINEAR_SCALING_FACTOR.put("custom", Renderer.minScalar);
+      foundInvalidSetting = true;
+    } else if (BILINEAR_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
+      BILINEAR_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
+      foundInvalidSetting = true;
+    }
+
+    if (BICUBIC_SCALING_FACTOR.get("custom") < Renderer.minScalar) {
+      BICUBIC_SCALING_FACTOR.put("custom", Renderer.minScalar);
+      foundInvalidSetting = true;
+    } else if (BICUBIC_SCALING_FACTOR.get("custom") > Renderer.maxInterpolationScalar) {
+      BICUBIC_SCALING_FACTOR.put("custom", Renderer.maxInterpolationScalar);
+      foundInvalidSetting = true;
+    }
+
+    if (WORLD.get("custom") < 0) {
+      WORLD.put("custom", 0);
+      foundInvalidSetting = true;
+    } else if (WORLD.get("custom") > Settings.WORLDS_TO_DISPLAY) {
+      WORLD.put("custom", Settings.WORLDS_TO_DISPLAY);
+      foundInvalidSetting = true;
+    }
+
+    if (SFX_VOLUME.get("custom") < 0) {
+      SFX_VOLUME.put("custom", 0);
+      foundInvalidSetting = true;
+    } else if (SFX_VOLUME.get("custom") > 100) {
+      SFX_VOLUME.put("custom", 100);
+      foundInvalidSetting = true;
+    }
+
+    if (VIEW_DISTANCE.get("custom") < 2300) {
+      VIEW_DISTANCE.put("custom", 2300);
+      foundInvalidSetting = true;
+    } else if (VIEW_DISTANCE.get("custom") > 20000) {
+      VIEW_DISTANCE.put("custom", 20000);
+      foundInvalidSetting = true;
+    }
+
+    if (TRACKPAD_ROTATION_SENSITIVITY.get("custom") < 0) {
+      TRACKPAD_ROTATION_SENSITIVITY.put("custom", 0);
+      foundInvalidSetting = true;
+    } else if (TRACKPAD_ROTATION_SENSITIVITY.get("custom") > 16) {
+      TRACKPAD_ROTATION_SENSITIVITY.put("custom", 16);
+      foundInvalidSetting = true;
+    }
+
+    if (LAST_KNOWN_COMBAT_STYLE.get("custom") < Client.COMBAT_CONTROLLED) {
+      LAST_KNOWN_COMBAT_STYLE.put("custom", Client.COMBAT_CONTROLLED);
+      foundInvalidSetting = true;
+    } else if (LAST_KNOWN_COMBAT_STYLE.get("custom") > Client.COMBAT_DEFENSIVE) {
+      LAST_KNOWN_COMBAT_STYLE.put("custom", Client.COMBAT_DEFENSIVE);
+      foundInvalidSetting = true;
+    }
+
+    if (NAME_PATCH_TYPE.get("custom") < 0) {
+      NAME_PATCH_TYPE.put("custom", 0);
+      foundInvalidSetting = true;
+    } else if (NAME_PATCH_TYPE.get("custom") > 3) {
+      NAME_PATCH_TYPE.put("custom", 3);
+      foundInvalidSetting = true;
+    }
+
+    if (FATIGUE_FIGURES.get("custom") < 1) {
+      FATIGUE_FIGURES.put("custom", 1);
+      foundInvalidSetting = true;
+    } else if (FATIGUE_FIGURES.get("custom") > 7) {
+      FATIGUE_FIGURES.put("custom", 7);
+      foundInvalidSetting = true;
+    }
+
+    if (foundInvalidSetting) {
+      save("custom");
+    }
+  }
+
+  /** @return OS-agnostic string value of a path, unless the provided string is empty */
+  public static String sanitizeDirTextValue(String path) {
+    if ("".equals(path)) {
+      return path;
+    }
+
+    return new File(path).getAbsolutePath();
+  }
+
   /**
    * Determine whether we should default to dark mode for the app interface
    *
@@ -2557,7 +2634,41 @@ public class Settings {
     } catch (Exception e) {
     }
 
+    // Check to see if RSC+ has permissions to write to the current dir
+    try {
+      if (!Files.isWritable(new File(Settings.Dir.JAR).toPath())) {
+        String filePermissionsErrorMessage =
+            "<b>Error attempting to launch RSCPlus</b><br/>"
+                + "<br/>"
+                + "RSCPlus is unable to create configuration files in the following directory:"
+                + "<br/><br/>"
+                + new File(Dir.JAR).getAbsolutePath()
+                + "<br/><br/>"
+                + "You must either grant the appropriate permissions to this directory OR<br/>"
+                + "move the application to a different location.";
+        JPanel filePermissionsErrorPanel =
+            Util.createOptionMessagePanel(filePermissionsErrorMessage);
+
+        JOptionPane.showConfirmDialog(
+            Launcher.getInstance(),
+            filePermissionsErrorPanel,
+            "RSCPlus",
+            JOptionPane.DEFAULT_OPTION,
+            JOptionPane.ERROR_MESSAGE,
+            Launcher.scaled_icon_warn);
+
+        System.exit(0);
+      }
+    } catch (Exception e) {
+      Logger.Error("There was an error on startup checking for directory permissions.");
+      e.printStackTrace();
+    }
+
+    CONFIG_FILE = Dir.JAR + "/config.ini";
+
     // Load other directories
+    Dir.LOGS = Dir.JAR + "/logs";
+    Util.makeDirectory(Dir.LOGS);
     Dir.SCREENSHOT = Dir.JAR + "/screenshots";
     Util.makeDirectory(Dir.SCREENSHOT);
     Dir.MODS = Dir.JAR + "/mods";
@@ -2616,28 +2727,6 @@ public class Settings {
         loadKeybinds(props);
       }
 
-      // XP
-      int numberOfGoalers = getPropInt(props, "numberOfGoalers", 0);
-      String[] goalerUsernames = new String[numberOfGoalers];
-      for (int usernameID = 0; usernameID < numberOfGoalers; usernameID++) {
-        goalerUsernames[usernameID] = getPropString(props, "username" + usernameID, "");
-        Client.xpGoals.put(goalerUsernames[usernameID], new Integer[Client.NUM_SKILLS]);
-        Client.lvlGoals.put(goalerUsernames[usernameID], new Float[Client.NUM_SKILLS]);
-        for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
-          Client.xpGoals.get(goalerUsernames[usernameID])[skill] =
-              getPropInt(props, String.format("xpGoal%02d%03d", skill, usernameID), 0);
-          try {
-            Client.lvlGoals.get(goalerUsernames[usernameID])[skill] =
-                Float.parseFloat(
-                    getPropString(props, String.format("lvlGoal%02d%03d", skill, usernameID), "0"));
-          } catch (Exception e1) {
-            Client.lvlGoals.get(goalerUsernames[usernameID])[skill] = new Float(0);
-            Logger.Warn(
-                "Couldn't parse settings key "
-                    + String.format("lvlGoal%02d%03d", skill, usernameID));
-          }
-        }
-      }
       XPBar.pinnedBar = getPropBoolean(props, "pinXPBar", false);
       XPBar.pinnedSkill = getPropInt(props, "pinnedSkill", -1);
       XPBar.showActionCount = getPropBoolean(props, "showActionCount", true);
@@ -2657,7 +2746,7 @@ public class Settings {
     Properties props = new Properties();
 
     try {
-      File configFile = new File(Dir.JAR + "/config.ini");
+      File configFile = new File(Settings.CONFIG_FILE);
       if (!configFile.isDirectory()) {
         if (!configFile.exists()) {
           definePresets(props);
@@ -2666,7 +2755,7 @@ public class Settings {
         }
       }
 
-      FileInputStream in = new FileInputStream(Dir.JAR + "/config.ini");
+      FileInputStream in = new FileInputStream(Settings.CONFIG_FILE);
       props.load(in);
       in.close();
     } catch (Exception e) {
@@ -2674,6 +2763,76 @@ public class Settings {
       e.printStackTrace();
     }
     return props;
+  }
+
+  /**
+   * Reads character-specific settings that MUST be re-read from the config.ini file every time the
+   * user logs in, loading them into the static variables for this client instance. Doing so is
+   * necessary to accommodate multi-client use cases.
+   *
+   * @param reloadSelf Whether to update settings for the current character
+   */
+  public static void loadCharacterSpecificSettings(boolean reloadSelf) {
+    final Properties props = loadProps();
+    final String currentPlayerName = Util.formatPlayerName(Client.player_name);
+
+    // Combat styles
+    int numberOfCombatants = getPropInt(props, "numberOfCombatants", 0);
+    String[] combatantUsernames = new String[numberOfCombatants];
+    for (int usernameID = 0; usernameID < numberOfCombatants; usernameID++) {
+      combatantUsernames[usernameID] = getPropString(props, "cmbUsername" + usernameID, "");
+
+      if (!reloadSelf
+          && (combatantUsernames[usernameID].equals(currentPlayerName)
+              || combatantUsernames[usernameID].equals(Client.playerAlias))) {
+        continue;
+      }
+
+      int loadedCombatStyle =
+          getPropInt(props, String.format("cmbStyle%03d", usernameID), Client.COMBAT_AGGRESSIVE);
+      // Sanitize the value if it somehow got corrupted
+      if (loadedCombatStyle < Client.COMBAT_CONTROLLED) {
+        loadedCombatStyle = Client.COMBAT_CONTROLLED;
+      } else if (loadedCombatStyle > Client.COMBAT_DEFENSIVE) {
+        loadedCombatStyle = Client.COMBAT_DEFENSIVE;
+      }
+      Client.playerCombatStyles.put(combatantUsernames[usernameID], loadedCombatStyle);
+    }
+
+    // Only read from props on client initialization and logins
+    if (reloadSelf) {
+      LAST_KNOWN_COMBAT_STYLE.put(
+          "custom", Integer.parseInt((String) props.get("last_known_combat_style")));
+    }
+
+    // XP and level goals
+    int numberOfGoalers = getPropInt(props, "numberOfGoalers", 0);
+    String[] goalerUsernames = new String[numberOfGoalers];
+    for (int usernameID = 0; usernameID < numberOfGoalers; usernameID++) {
+      goalerUsernames[usernameID] = getPropString(props, "username" + usernameID, "");
+
+      if (!reloadSelf
+          && (goalerUsernames[usernameID].equals(currentPlayerName)
+              || goalerUsernames[usernameID].equals(Client.playerAlias))) {
+        continue;
+      }
+
+      Client.xpGoals.put(goalerUsernames[usernameID], new Integer[Client.NUM_SKILLS]);
+      Client.lvlGoals.put(goalerUsernames[usernameID], new Float[Client.NUM_SKILLS]);
+      for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
+        Client.xpGoals.get(goalerUsernames[usernameID])[skill] =
+            getPropInt(props, String.format("xpGoal%02d%03d", skill, usernameID), 0);
+        try {
+          Client.lvlGoals.get(goalerUsernames[usernameID])[skill] =
+              Float.parseFloat(
+                  getPropString(props, String.format("lvlGoal%02d%03d", skill, usernameID), "0"));
+        } catch (Exception e1) {
+          Client.lvlGoals.get(goalerUsernames[usernameID])[skill] = new Float(0);
+          Logger.Warn(
+              "Couldn't parse settings key " + String.format("lvlGoal%02d%03d", skill, usernameID));
+        }
+      }
+    }
   }
 
   public static void loadKeybinds(Properties props) {
@@ -2690,6 +2849,33 @@ public class Settings {
     }
 
     resolveNewDefaults();
+  }
+
+  /**
+   * Validates a provided directory path by checking for its existence and write-ability
+   *
+   * @param dir Directory to validate
+   * @param fallback Fallback directory to return if validation fails
+   * @return String value of the provided directory if valid, or sanitized fallback if not
+   */
+  public static String validateCustomDir(String dir, String fallback) {
+    final String sanitizedFallback = sanitizeDirTextValue(fallback);
+
+    if ("".equals(dir)) {
+      return sanitizedFallback;
+    }
+
+    File dirFile = new File(dir);
+
+    if (!(dirFile.exists())) {
+      return sanitizedFallback;
+    }
+
+    if (!Files.isWritable(dirFile.toPath())) {
+      return sanitizedFallback;
+    }
+
+    return dir;
   }
 
   /**
@@ -2736,27 +2922,22 @@ public class Settings {
     int i = 1;
     if (fList != null) {
       for (File worldFile : fList) {
-        if (!worldFile.isDirectory() && !worldFile.getName().equals(".DS_Store")) {
-          Properties worldProps = new Properties();
-          try {
-            FileInputStream in = new FileInputStream(worldFile);
-            worldProps.load(in);
-            in.close();
+        if (!worldFile.getName().equals(".DS_Store")) {
+          Properties worldProps = validateWorldFile(worldFile);
 
-            WORLD_FILE_PATHS.put(i, worldFile.getAbsolutePath());
-            WORLD_NAMES.put(i, worldProps.getProperty("name"));
-            WORLD_URLS.put(i, worldProps.getProperty("url"));
-            WORLD_PORTS.put(i, Integer.parseInt(worldProps.getProperty("port")));
-            WORLD_SERVER_TYPES.put(
-                i, Integer.parseInt((String) worldProps.getOrDefault("servertype", "1")));
-            WORLD_RSA_PUB_KEYS.put(i, worldProps.getProperty("rsa_pub_key"));
-            WORLD_RSA_EXPONENTS.put(i, worldProps.getProperty("rsa_exponent"));
-            WORLD_HISCORES_URL.put(i, (String) worldProps.getOrDefault("hiscores_url", ""));
+          if (worldProps == null) continue;
 
-            i++;
-          } catch (Exception e) {
-            Logger.Warn("Error loading World config for " + worldFile.getAbsolutePath());
-          }
+          WORLD_FILE_PATHS.put(i, worldFile.getAbsolutePath());
+          WORLD_NAMES.put(i, worldProps.getProperty("name"));
+          WORLD_URLS.put(i, worldProps.getProperty("url"));
+          WORLD_PORTS.put(i, Integer.parseInt(worldProps.getProperty("port")));
+          WORLD_SERVER_TYPES.put(
+              i, Integer.parseInt((String) worldProps.getOrDefault("servertype", "1")));
+          WORLD_RSA_PUB_KEYS.put(i, worldProps.getProperty("rsa_pub_key"));
+          WORLD_RSA_EXPONENTS.put(i, worldProps.getProperty("rsa_exponent"));
+          WORLD_HISCORES_URL.put(i, (String) worldProps.getOrDefault("hiscores_url", ""));
+
+          i++;
         }
       }
     }
@@ -2768,6 +2949,27 @@ public class Settings {
       createNewWorld(1);
       WORLDS_TO_DISPLAY = 1;
     }
+  }
+
+  /**
+   * Ensures that a world file can be properly parsed into a properties file
+   *
+   * @param worldFile {@link File} reference for the world ini
+   * @return parsed world file {@link Properties} or {@code null} if invalid
+   */
+  public static Properties validateWorldFile(File worldFile) {
+    if (!worldFile.isDirectory() && worldFile.getName().endsWith(".ini")) {
+      try (FileInputStream in = new FileInputStream(worldFile)) {
+        Properties worldProps = new Properties();
+        worldProps.load(in);
+        return worldProps;
+      } catch (Exception e) {
+        // Will fall through below
+      }
+    }
+
+    Logger.Warn("Error loading World config for " + worldFile.getAbsolutePath());
+    return null;
   }
 
   public static void saveWorlds() {
@@ -3002,6 +3204,7 @@ public class Settings {
       props.setProperty(
           "ran_effect_target_fps", Integer.toString(RAN_EFFECT_TARGET_FPS.get(preset)));
       props.setProperty("auto_screenshot", Boolean.toString(AUTO_SCREENSHOT.get(preset)));
+      props.setProperty("screenshots_storage_path", SCREENSHOTS_STORAGE_PATH.get(preset));
       props.setProperty("rs2hd_sky", Boolean.toString(RS2HD_SKY.get(preset)));
       props.setProperty(
           "custom_ran_static_colour", Integer.toString(CUSTOM_RAN_STATIC_COLOUR.get(preset)));
@@ -3158,8 +3361,8 @@ public class Settings {
       props.setProperty("show_xp_bar", Boolean.toString(SHOW_XP_BAR.get(preset)));
       props.setProperty("debug", Boolean.toString(DEBUG.get(preset)));
       props.setProperty("exception_handler", Boolean.toString(EXCEPTION_HANDLER.get(preset)));
-      props.setProperty("highlighted_items", Util.joinAsString(",", HIGHLIGHTED_ITEMS.get(preset)));
-      props.setProperty("blocked_items", Util.joinAsString(",", BLOCKED_ITEMS.get(preset)));
+      props.setProperty("highlighted_items", String.join(",", HIGHLIGHTED_ITEMS.get(preset)));
+      props.setProperty("blocked_items", String.join(",", BLOCKED_ITEMS.get(preset)));
       props.setProperty(
           "item_highlight_colour", Integer.toString(ITEM_HIGHLIGHT_COLOUR.get(preset)));
       props.setProperty(
@@ -3183,7 +3386,7 @@ public class Settings {
       props.setProperty(
           "use_system_notifications", Boolean.toString(USE_SYSTEM_NOTIFICATIONS.get(preset)));
       props.setProperty("pm_notifications", Boolean.toString(PM_NOTIFICATIONS.get(preset)));
-      props.setProperty("pm_denylist", Util.joinAsString(",", PM_DENYLIST.get(preset)));
+      props.setProperty("pm_denylist", String.join(",", PM_DENYLIST.get(preset)));
       props.setProperty("trade_notifications", Boolean.toString(TRADE_NOTIFICATIONS.get(preset)));
       props.setProperty("duel_notifications", Boolean.toString(DUEL_NOTIFICATIONS.get(preset)));
       props.setProperty("logout_notifications", Boolean.toString(LOGOUT_NOTIFICATIONS.get(preset)));
@@ -3198,10 +3401,9 @@ public class Settings {
       props.setProperty(
           "highlighted_item_notif_value",
           Integer.toString(HIGHLIGHTED_ITEM_NOTIF_VALUE.get(preset)));
+      props.setProperty("important_messages", String.join(",", IMPORTANT_MESSAGES.get(preset)));
       props.setProperty(
-          "important_messages", Util.joinAsString(",", IMPORTANT_MESSAGES.get(preset)));
-      props.setProperty(
-          "important_sad_messages", Util.joinAsString(",", IMPORTANT_SAD_MESSAGES.get(preset)));
+          "important_sad_messages", String.join(",", IMPORTANT_SAD_MESSAGES.get(preset)));
       props.setProperty(
           "mute_important_message_sounds",
           Boolean.toString(MUTE_IMPORTANT_MESSAGE_SOUNDS.get(preset)));
@@ -3219,6 +3421,7 @@ public class Settings {
       // props.setProperty("speedrun_username", Settings.SPEEDRUNNER_USERNAME.get(preset));
 
       //// replay
+      props.setProperty("replay_storage_path", REPLAY_STORAGE_PATH.get(preset));
       props.setProperty("record_kb_mouse", Boolean.toString(RECORD_KB_MOUSE.get(preset)));
       props.setProperty("parse_opcodes", Boolean.toString(PARSE_OPCODES.get(preset)));
       props.setProperty("fast_disconnect", Boolean.toString(FAST_DISCONNECT.get(preset)));
@@ -3244,7 +3447,8 @@ public class Settings {
       props.setProperty("joystick_enabled", Boolean.toString(JOYSTICK_ENABLED.get(preset)));
 
       //// no gui
-      props.setProperty("combat_style", Integer.toString(COMBAT_STYLE.get(preset)));
+      props.setProperty(
+          "last_known_combat_style", Integer.toString(LAST_KNOWN_COMBAT_STYLE.get(preset)));
       props.setProperty("world", Integer.toString(WORLD.get(preset)));
       // This is set to false, as logically, saving the config would imply this is not a first-run.
       props.setProperty("first_time", Boolean.toString(false));
@@ -3262,10 +3466,28 @@ public class Settings {
             Integer.toString(getPropIntForKeyModifier(kbs)) + "*" + kbs.key);
       }
 
+      // Reload other char settings before re-saving to resolve differences when multi-clienting
+      // Note: Skip on 1st client load, as the config file won't exist yet
+      if (new File(Settings.CONFIG_FILE).exists()) {
+        loadCharacterSpecificSettings(false);
+      }
+
+      // Combat styles
+      int combatUsernameID = 0;
+      for (String username : Client.playerCombatStyles.keySet()) {
+        if (username.equals(Replay.excludeUsername)) continue;
+        int combatStyle = Client.playerCombatStyles.get(username);
+        props.setProperty(
+            String.format("cmbStyle%03d", combatUsernameID), Integer.toString(combatStyle));
+        props.setProperty(String.format("cmbUsername%d", combatUsernameID), username);
+        combatUsernameID++;
+      }
+      props.setProperty("numberOfCombatants", String.format("%d", combatUsernameID));
+
       // XP Goals
-      int usernameID = 0;
+      int xpUsernameID = 0;
       for (String username : Client.xpGoals.keySet()) {
-        if (username.equals(XPBar.excludeUsername)) continue;
+        if (username.equals(Replay.excludeUsername)) continue;
         for (int skill = 0; skill < Client.NUM_SKILLS; skill++) {
           int skillgoal = 0;
           try {
@@ -3280,14 +3502,14 @@ public class Settings {
           }
 
           props.setProperty(
-              String.format("xpGoal%02d%03d", skill, usernameID), Integer.toString(skillgoal));
+              String.format("xpGoal%02d%03d", skill, xpUsernameID), Integer.toString(skillgoal));
           props.setProperty(
-              String.format("lvlGoal%02d%03d", skill, usernameID), Float.toString(lvlgoal));
+              String.format("lvlGoal%02d%03d", skill, xpUsernameID), Float.toString(lvlgoal));
         }
-        props.setProperty(String.format("username%d", usernameID), username);
-        usernameID++;
+        props.setProperty(String.format("username%d", xpUsernameID), username);
+        xpUsernameID++;
       }
-      props.setProperty("numberOfGoalers", String.format("%d", usernameID));
+      props.setProperty("numberOfGoalers", String.format("%d", xpUsernameID));
 
       props.setProperty("pinXPBar", Boolean.toString(XPBar.pinnedBar));
       props.setProperty("pinnedSkill", String.format("%d", XPBar.pinnedSkill));
@@ -3306,7 +3528,7 @@ public class Settings {
       props.setProperty(
           "worldmap_show_other_floors", Boolean.toString(WorldMapWindow.showOtherFloors));
 
-      FileOutputStream out = new FileOutputStream(Dir.JAR + "/config.ini");
+      FileOutputStream out = new FileOutputStream(Settings.CONFIG_FILE);
       props.store(out, "---rscplus config---");
       out.close();
     } catch (Exception e) {
@@ -4199,6 +4421,7 @@ public class Settings {
 
     public static String JAR;
     public static String DUMP;
+    public static String LOGS;
     public static String SCREENSHOT;
     public static String VIDEO;
     public static String MODS;
@@ -4523,9 +4746,10 @@ public class Settings {
     Launcher.getConfigWindow().synchronizeGuiValues();
   }
 
+  /** Note: This gets invoked nonstop during gameplay */
   public static void updateInjectedVariables() {
     // TODO: get rid of these variables and this function if possible
-    COMBAT_STYLE_INT = COMBAT_STYLE.get(currentProfile);
+    COMBAT_STYLE_INT = Client.combat_style;
     HIDE_ROOFS_BOOL = HIDE_ROOFS.get(currentProfile);
     DISABLE_UNDERGROUND_LIGHTING_BOOL = DISABLE_UNDERGROUND_LIGHTING.get(currentProfile);
     DISABLE_MINIMAP_ROTATION_BOOL = DISABLE_MINIMAP_ROTATION.get(currentProfile);
@@ -4541,9 +4765,24 @@ public class Settings {
     ITEM_HIGHLIGHT_COLOUR_INT = ITEM_HIGHLIGHT_COLOUR.get(currentProfile);
   }
 
+  /** Invoked when combat style changes */
   public static void outputInjectedVariables() {
     // TODO: get rid of these variables and this function if possible
-    COMBAT_STYLE.put(currentProfile, COMBAT_STYLE_INT);
+
+    if (Client.player_name.isEmpty() || Client.username_login.equals(Replay.excludeUsername)) {
+      return;
+    }
+
+    // Save character-specific combat style
+    Client.playerCombatStyles.put(Util.formatPlayerName(Client.player_name), COMBAT_STYLE_INT);
+
+    // If an alias exists, save to it as well
+    if (!Client.playerAlias.isEmpty()) {
+      Client.playerCombatStyles.put(Client.playerAlias, COMBAT_STYLE_INT);
+    }
+
+    // Save to the global previously-known combat style as a fallback
+    LAST_KNOWN_COMBAT_STYLE.put("custom", COMBAT_STYLE_INT);
   }
 
   /**

--- a/src/Client/Speedrun.java
+++ b/src/Client/Speedrun.java
@@ -98,7 +98,7 @@ public class Speedrun {
     if (Settings.SPEEDRUNNER_MODE_ACTIVE.get(Settings.currentProfile)) {
       for (messageGoal goal : messageGoal.values()) {
         if (completionTimes[goal.id] == 0) {
-          if (goal.systemMessage == message) {
+          if (goal.systemMessage.equals(message)) {
             completionTicks[goal.id] = totalTicks;
             completionTimes[goal.id] = System.currentTimeMillis();
             printGoalCompletion(goal.name, completionTicks[goal.id], completionTimes[goal.id]);

--- a/src/Client/TrayHandler.java
+++ b/src/Client/TrayHandler.java
@@ -20,6 +20,7 @@ package Client;
 
 import static Client.Util.osScaleMul;
 
+import Client.ConfigWindow.ConfigTab;
 import Game.Game;
 import java.awt.AWTException;
 import java.awt.Font;
@@ -78,22 +79,15 @@ public class TrayHandler implements MouseListener {
 
     JTabbedPane settingsTabbedPane = Launcher.getConfigWindow().tabbedPane;
 
-    int authorsTabIndex = -1;
-    for (int i = 0; i < settingsTabbedPane.getTabCount(); i++) {
-      if (settingsTabbedPane.getTitleAt(i).equals(ConfigWindow.ConfigTab.AUTHORS.getLabel())) {
-        authorsTabIndex = i;
-        break;
-      }
-    }
+    int authorsTabIndex = ConfigTab.getTabIndex(ConfigTab.AUTHORS);
 
     if (authorsTabIndex > -1) {
-      int finalAuthorsTabIndex = authorsTabIndex;
       about.addActionListener(
           new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
               Launcher.getConfigWindow().setInitiatedTab(-1); // Reset current tab
-              settingsTabbedPane.setSelectedIndex(finalAuthorsTabIndex);
+              settingsTabbedPane.setSelectedIndex(authorsTabIndex);
               Launcher.getConfigWindow().showConfigWindow();
             }
           });

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -770,8 +770,8 @@ public class Util {
   }
 
   public static boolean detectBinaryAvailable(String binaryName, String reason) {
-    if (Util.isWindowsOS() || Util.isMacOS()) {
-      return false; // don't trust Windows or macOS to run the detection code
+    if (Util.isWindowsOS()) {
+      return false; // don't trust Windows to run the detection code
     }
 
     try {
@@ -780,7 +780,7 @@ public class Util {
       final String whereis =
           execCmd(new String[] {"whereis", "-b", binaryName})
               .replace("\n", "")
-              .replace(binaryName + ": ", "");
+              .replace(binaryName + ":", "");
       if (whereis.length() < ("/" + binaryName).length()) {
         Logger.Error(
             String.format(

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -739,7 +739,7 @@ public class Util {
    * that equivalent login names can be tracked in a consistent manner.
    */
   public static String formatPlayerName(String name) {
-    return name.replaceAll("[^=,\\da-zA-Z\\s]|(?<!,)\\s", " ").toLowerCase().trim();
+    return name.replaceAll("[^a-zA-Z0-9@._\\-\\s]|(?<!,)\\s", " ").toLowerCase().trim();
   }
 
   public static int boundUnsignedShort(String num) throws NumberFormatException {
@@ -770,8 +770,8 @@ public class Util {
   }
 
   public static boolean detectBinaryAvailable(String binaryName, String reason) {
-    if (System.getProperty("os.name").contains("Windows")) {
-      return false; // don't trust Windows to run the detection code
+    if (Util.isWindowsOS() || Util.isMacOS()) {
+      return false; // don't trust Windows or macOS to run the detection code
     }
 
     try {
@@ -799,7 +799,7 @@ public class Util {
   }
 
   public static boolean notMacWindows() {
-    if (System.getProperty("os.name").contains("Windows")) {
+    if (Util.isWindowsOS()) {
       return false;
     }
     return !isMacOS();
@@ -812,7 +812,11 @@ public class Util {
    */
   public static void openDirectory(File directory) {
     try {
-      Desktop.getDesktop().open(directory);
+      if (Settings.PREFERS_XDG_OPEN.get(Settings.currentProfile) && Util.hasXdgOpen) {
+        Util.execCmd(new String[] {"xdg-open", directory.toString()});
+      } else {
+        Desktop.getDesktop().open(directory);
+      }
     } catch (Exception e) {
       Logger.Error("Error opening directory: [" + directory.toString() + "]");
       e.printStackTrace();

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -583,25 +583,6 @@ public class Util {
     */
   }
 
-  /**
-   * Polyfill for Java 8 `String.join`
-   *
-   * <p>Convert an arraylist of strings to a single string, where each element is separated by some
-   * deliminator.
-   *
-   * @param delim The string to use when combining elements
-   * @param list The list to combine
-   * @return The string of the arraylist
-   */
-  public static String joinAsString(String delim, ArrayList<String> list) {
-    StringBuilder sb = new StringBuilder();
-    for (String s : list) {
-      sb.append(s);
-      sb.append(delim);
-    }
-    return sb.toString();
-  }
-
   public static List<File> getAllReplays(List<File> folderInputs) {
     ReplayQueue.foundBrokenReplay = false;
     List<File> potentialReplayFolders = new ArrayList<File>();
@@ -753,6 +734,14 @@ public class Util {
     return res;
   }
 
+  /**
+   * Formats a character name by escaping special characters in the same way the server would, such
+   * that equivalent login names can be tracked in a consistent manner.
+   */
+  public static String formatPlayerName(String name) {
+    return name.replaceAll("[^=,\\da-zA-Z\\s]|(?<!,)\\s", " ").toLowerCase().trim();
+  }
+
   public static int boundUnsignedShort(String num) throws NumberFormatException {
     int result;
     int limit = Short.MAX_VALUE - Short.MIN_VALUE;
@@ -814,6 +803,20 @@ public class Util {
       return false;
     }
     return !isMacOS();
+  }
+
+  /**
+   * Opens a directory in the user's system file explorer
+   *
+   * @param directory {@link File} instance for the provided directory
+   */
+  public static void openDirectory(File directory) {
+    try {
+      Desktop.getDesktop().open(directory);
+    } catch (Exception e) {
+      Logger.Error("Error opening directory: [" + directory.toString() + "]");
+      e.printStackTrace();
+    }
   }
 
   public static void openLinkInBrowser(String url) {

--- a/src/Client/Util.java
+++ b/src/Client/Util.java
@@ -788,7 +788,7 @@ public class Util {
                 binaryName, reason));
         return false;
       } else {
-        Logger.Info(binaryName + ": " + whereis);
+        Logger.Info(binaryName + ":" + whereis);
         return true;
       }
     } catch (IOException e) {

--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -775,7 +775,7 @@ public class WorldMapWindow {
 
             buildSearchResults();
 
-            if (prevSearchText != searchText) {
+            if (!prevSearchText.equals(searchText)) {
               mapView.repaint();
             }
           }

--- a/src/Game/Camera.java
+++ b/src/Game/Camera.java
@@ -301,7 +301,7 @@ public class Camera {
   }
 
   public static void resetRotation() {
-    rotation = 126;
+    rotation = 128;
     delta_rotation = (float) rotation;
   }
 

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -225,6 +225,8 @@ public class Client {
   public static Object player_object;
   public static String player_name = "";
   public static int player_id = -1;
+  public static boolean resolvedName = false;
+  public static String playerAlias = "";
   public static String xpUsername = "";
   public static boolean knowWhoIAm = false;
   public static int player_posX = -1;
@@ -341,6 +343,9 @@ public class Client {
   // second dimension is the constants in block above.
   private static HashMap<String, Double[][]> lastXpGain = new HashMap<String, Double[][]>();
 
+  // player name -> combat style
+  public static HashMap<String, Integer> playerCombatStyles = new HashMap<>();
+
   // holds players XP since last processing xp drops
   private static HashMap<String, Float[]> xpLast = new HashMap<String, Float[]>();
 
@@ -416,6 +421,7 @@ public class Client {
   public static boolean showContactDetails;
 
   public static boolean firstTimeRunningRSCPlus = false;
+  public static boolean customSfxVolumeSet = false;
 
   public static int mouse_click;
   public static boolean singleButtonMode;
@@ -941,6 +947,12 @@ public class Client {
         AreaDefinition area = getCurrentAreaDefinition();
         MusicPlayer.playTrack(area.music);
       } else if (state == STATE_LOGIN) {
+        // Set the client volume
+        if (!customSfxVolumeSet) {
+          SoundEffects.adjustMudClientSfxVolume();
+          customSfxVolumeSet = true;
+        }
+
         MusicPlayer.playTrack(loginTrack);
       }
     }
@@ -1028,6 +1040,10 @@ public class Client {
 
     if (state == STATE_GAME) {
       Client.getPlayerName();
+
+      // Resolve combat style when the server name does not match logged in name
+      resolveCombatStyle();
+
       player_id = Client.getPlayerId();
       Client.adaptLoginInfo();
     }
@@ -1087,6 +1103,59 @@ public class Client {
       update_timer = time + 1000;
       updates = 0;
     }
+  }
+
+  /** Handles combat style resolution when logged in name does not match player's server name */
+  private static void resolveCombatStyle() {
+    // Only compare one time, once the server player name is known
+    if (resolvedName || !knowWhoIAm) {
+      return;
+    }
+
+    final String loginPlayerName = Util.formatPlayerName(username_login);
+    final String serverPlayerName = Util.formatPlayerName(player_name);
+
+    // Skip resolution logic if in replay
+    if (loginPlayerName.equals(Replay.excludeUsername)) {
+      resolvedName = true;
+      return;
+    }
+
+    // logged in with bob, server returned alice
+    if (!loginPlayerName.equals(serverPlayerName)) {
+      // save off bob as the alias, so further writes to alice can be done for bob as well
+      playerAlias = loginPlayerName;
+
+      // see if alice has a saved value
+      Integer serverPlayerNameCombatStyle = playerCombatStyles.get(serverPlayerName);
+
+      if (serverPlayerNameCombatStyle == null) {
+        // if alice does not have anything saved, save bob's current style to alice
+        playerCombatStyles.put(serverPlayerName, combat_style);
+        // further changes will be saved to alice
+      } else {
+        // if alice has an existing value that does not match bob's, load and save it for bob
+        if (serverPlayerNameCombatStyle != combat_style) {
+          combat_style = serverPlayerNameCombatStyle;
+          playerCombatStyles.put(loginPlayerName, combat_style);
+        }
+      }
+
+      // Save results of the above resolution
+      Settings.LAST_KNOWN_COMBAT_STYLE.put("custom", combat_style);
+      Settings.save();
+    } else {
+      // Re-save last-known style on login when it has changed asynchronously
+      if (combat_style != Settings.LAST_KNOWN_COMBAT_STYLE.get("custom")) {
+        Settings.LAST_KNOWN_COMBAT_STYLE.put("custom", combat_style);
+        Settings.save();
+      }
+    }
+
+    // Re-send combat style packet just in case
+    sendCombatStylePacket(combat_style);
+
+    resolvedName = true;
   }
 
   public static void processFatigueXPDrops() {
@@ -1170,7 +1239,7 @@ public class Client {
       return;
     }
 
-    xpUsername = Util.formatString(username_login, 50);
+    xpUsername = Util.formatPlayerName(username_login);
     if (lastXpGain.get(xpUsername) == null) {
       lastXpGain.put(xpUsername, new Double[NUM_SKILLS][5]);
       showXpPerHour.put(xpUsername, new Boolean[NUM_SKILLS]);
@@ -1207,6 +1276,7 @@ public class Client {
     }
   }
 
+  /** Invoked on login and logout */
   public static void init_login() {
     Camera.init();
     state = STATE_LOGIN;
@@ -1227,15 +1297,34 @@ public class Client {
     player_id = -1;
   }
 
+  /* Invoked on login */
   public static void init_game() {
     Camera.init();
-    combat_style = Settings.COMBAT_STYLE.get(Settings.currentProfile);
+
+    // Load character-specific settings such as combat styles and XP goals on each login
+    Settings.loadCharacterSpecificSettings(true);
+
+    // Escape username from login input
+    final String escapedUsername = Util.formatPlayerName(username_login);
+
+    // Set combat style in mudclient when not in a replay
+    if (!escapedUsername.equals(Replay.excludeUsername)) {
+      // Attempt to find character-specific combat style
+      Integer foundCombatStyle = playerCombatStyles.get(escapedUsername);
+
+      if (foundCombatStyle != null) {
+        combat_style = foundCombatStyle;
+      } else {
+        // Fall back to the global previously-known combat style and store it
+        combat_style = Settings.LAST_KNOWN_COMBAT_STYLE.get("custom");
+        playerCombatStyles.put(escapedUsername, combat_style);
+        Settings.save();
+      }
+    }
+
     state = STATE_GAME;
     // bank_active_page = 0; // TODO: config option? don't think this is very important.
     // combat_timer = 0;
-
-    // Set the client volume
-    SoundEffects.adjustMudClientSfxVolume();
   }
 
   public static void login_hook() {
@@ -1304,13 +1393,18 @@ public class Client {
     // Re-validate the current scaling upon logging in, in case something
     // went wrong during the initial window creation and resizing.
     ScaledWindow.getInstance().validateAppletSize();
+
+    // Re-send combat style packet just in case
+    sendCombatStylePacket(combat_style);
   }
 
   public static void disconnect_hook() {
     // ::lostcon or closeConnection
     Replay.closeReplayRecording();
     Speedrun.saveAndQuitSpeedrun();
+    resolvedName = false;
     player_name = "";
+    playerAlias = "";
     player_id = -1;
     knowWhoIAm = false;
     Client.tipOfDay = -1;
@@ -1603,6 +1697,15 @@ public class Client {
     } catch (IllegalArgumentException | IllegalAccessException e1) {
       e1.printStackTrace();
     }
+  }
+
+  /** Sends a packet to update the user's combat style */
+  public static void sendCombatStylePacket(int combatStyle) {
+    StreamUtil.newPacket(29);
+
+    Object buffer = StreamUtil.getStreamBuffer();
+    StreamUtil.putByteTo(buffer, (byte) combatStyle);
+    StreamUtil.sendPacket();
   }
 
   /** Stores the user's pid in {@link #player_id}. */
@@ -2478,7 +2581,7 @@ public class Client {
           Reflection.drawString.invoke(
               surfaceInstance,
               "Fps: "
-                  + (Client.username_login.equals(XPBar.excludeUsername)
+                  + (Client.username_login.equals(Replay.excludeUsername)
                       ? Renderer.fps
                       : Client.fps),
               Renderer.width - 62 - offset,
@@ -3568,6 +3671,11 @@ public class Client {
         || showAppearanceChange
         || showRecoveryQuestions
         || showContactDetails;
+  }
+
+  /** Returns {@code true} if a full-screen in-game interface is currently displayed. */
+  public static boolean isFullScreenInterfaceOpen() {
+    return show_sleeping || show_appearance || showRecoveryQuestions || showContactDetails;
   }
 
   /**

--- a/src/Game/JoystickHandler.java
+++ b/src/Game/JoystickHandler.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import javax.swing.*;
 import net.java.games.input.Component;
 import net.java.games.input.Controller;
 import net.java.games.input.ControllerEnvironment;

--- a/src/Game/MusicPlayer.java
+++ b/src/Game/MusicPlayer.java
@@ -156,7 +156,7 @@ public class MusicPlayer implements Runnable {
 
   public static void playTrack(MusicDef track) {
     // Track didn't change
-    if (switchTrack.equals(track.filename)) return;
+    if (switchTrack.filename.equals(track.filename)) return;
 
     // Switch track
     switchTrack = track;

--- a/src/Game/Renderer.java
+++ b/src/Game/Renderer.java
@@ -669,7 +669,8 @@ public class Renderer {
       Client.item_list.clear();
       last_item = null;
 
-      if (!Client.show_sleeping && Settings.SHOW_INVCOUNT.get(Settings.currentProfile))
+      if (!Client.isFullScreenInterfaceOpen()
+          && Settings.SHOW_INVCOUNT.get(Settings.currentProfile)) {
         drawShadowText(
             g2,
             Client.inventory_count + "/" + Client.max_inventory,
@@ -677,6 +678,7 @@ public class Renderer {
             17,
             getInventoryCountColor(),
             true);
+      }
 
       int percentHP = 0;
       int percentPrayer = 0;
@@ -924,7 +926,9 @@ public class Renderer {
       // render XP bar/drop
       Client.processFatigueXPDrops();
       Client.xpdrop_handler.draw(g2);
-      Client.xpbar.draw(g2, bufferedMouseClick);
+      if (!Client.isFullScreenInterfaceOpen()) { // Prevent crashes on new character creation
+        Client.xpbar.draw(g2, bufferedMouseClick);
+      }
 
       if (!Client.isSleeping()) {
         Client.updateCurrentFatigue();
@@ -1006,7 +1010,8 @@ public class Renderer {
         }
       }
 
-      if (Settings.WIKI_LOOKUP_ON_HBAR.get(Settings.currentProfile)) {
+      if (!Client.isFullScreenInterfaceOpen()
+          && Settings.WIKI_LOOKUP_ON_HBAR.get(Settings.currentProfile)) {
         int xCoord = Client.wikiLookupReplacesReportAbuse() ? 410 : 410 + 90 + 12;
         int yCoord = height - 16;
         // Handle wiki lookup click
@@ -1078,16 +1083,7 @@ public class Renderer {
         if ((!show_bank_last || mapButtonBounds.x >= 460) && !Client.show_sleeping) {
           if (Settings.SHOW_RSCPLUS_BUTTONS.get(Settings.currentProfile)) {
             g2.setColor(Renderer.color_text);
-            g2.drawLine(
-                mapButtonBounds.x + 4,
-                mapButtonBounds.y + 1,
-                mapButtonBounds.x + 4,
-                mapButtonBounds.y + 1 + 6);
-            g2.drawLine(
-                mapButtonBounds.x + 1,
-                mapButtonBounds.y + 4,
-                mapButtonBounds.x + 7,
-                mapButtonBounds.y + 4);
+            drawPlusIcon(g2, mapButtonBounds.x, mapButtonBounds.y);
           }
 
           // Handle map button click
@@ -1106,16 +1102,7 @@ public class Renderer {
         if ((!show_bank_last || mapButtonBounds.x >= 460) && !Client.show_sleeping) {
           if (Settings.SHOW_RSCPLUS_BUTTONS.get(Settings.currentProfile)) {
             g2.setColor(Renderer.color_text);
-            g2.drawLine(
-                mapButtonBounds.x + 4,
-                mapButtonBounds.y + 1,
-                mapButtonBounds.x + 4,
-                mapButtonBounds.y + 1 + 6);
-            g2.drawLine(
-                mapButtonBounds.x + 1,
-                mapButtonBounds.y + 4,
-                mapButtonBounds.x + 7,
-                mapButtonBounds.y + 4);
+            drawPlusIcon(g2, mapButtonBounds.x, mapButtonBounds.y);
           }
 
           // Handle settings button click
@@ -1134,16 +1121,7 @@ public class Renderer {
           if ((!show_bank_last || mapButtonBounds.x >= 460) && !Client.show_sleeping) {
             if (Settings.SHOW_RSCPLUS_BUTTONS.get(Settings.currentProfile)) {
               g2.setColor(Renderer.color_text);
-              g2.drawLine(
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1,
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1 + 6);
-              g2.drawLine(
-                  mapButtonBounds.x + 1,
-                  mapButtonBounds.y + 4,
-                  mapButtonBounds.x + 7,
-                  mapButtonBounds.y + 4);
+              drawPlusIcon(g2, mapButtonBounds.x, mapButtonBounds.y);
             }
 
             // Handle magic book button click
@@ -1168,16 +1146,7 @@ public class Renderer {
           if ((!show_bank_last || mapButtonBounds.x >= 460) && !Client.show_sleeping) {
             if (Settings.SHOW_RSCPLUS_BUTTONS.get(Settings.currentProfile)) {
               g2.setColor(Renderer.color_text);
-              g2.drawLine(
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1,
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1 + 6);
-              g2.drawLine(
-                  mapButtonBounds.x + 1,
-                  mapButtonBounds.y + 4,
-                  mapButtonBounds.x + 7,
-                  mapButtonBounds.y + 4);
+              drawPlusIcon(g2, mapButtonBounds.x, mapButtonBounds.y);
             }
 
             // Handle friends button click
@@ -1218,16 +1187,7 @@ public class Renderer {
           if ((!show_bank_last || mapButtonBounds.x >= 460) && !Client.show_sleeping) {
             if (Settings.SHOW_RSCPLUS_BUTTONS.get(Settings.currentProfile)) {
               g2.setColor(Renderer.color_text);
-              g2.drawLine(
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1,
-                  mapButtonBounds.x + 4,
-                  mapButtonBounds.y + 1 + 6);
-              g2.drawLine(
-                  mapButtonBounds.x + 1,
-                  mapButtonBounds.y + 4,
-                  mapButtonBounds.x + 7,
-                  mapButtonBounds.y + 4);
+              drawPlusIcon(g2, mapButtonBounds.x, mapButtonBounds.y);
             }
 
             // Handle stats menu click
@@ -2231,7 +2191,11 @@ public class Renderer {
       try {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH.mm.ss");
         String fname =
-            Settings.Dir.SCREENSHOT + "/" + "Screenshot from " + format.format(new Date()) + ".png";
+            Settings.SCREENSHOTS_STORAGE_PATH.get("custom")
+                + "/"
+                + "Screenshot from "
+                + format.format(new Date())
+                + ".png";
         File screenshotFile = new File(fname);
         ImageIO.write(game_image, "png", screenshotFile);
         if (!quietScreenshot)
@@ -2240,6 +2204,8 @@ public class Renderer {
       } catch (Exception e) {
       }
     }
+
+    // Rapid screenshots should not use custom-set screenshot dirs
 
     if (videorecord > 0) {
       String fname = Settings.Dir.VIDEO + "/" + "video" + (videolength - videorecord) + ".png";
@@ -2390,6 +2356,16 @@ public class Renderer {
 
     // state of show_bank "last frame"
     show_bank_last = Client.show_bank;
+  }
+
+  /** Draws a little + symbol over menu buttons */
+  private static void drawPlusIcon(Graphics2D g2, int x, int y) {
+    if (Client.isFullScreenInterfaceOpen()) {
+      return;
+    }
+
+    g2.drawLine(x + 4, y + 1, x + 4, y + 1 + 6);
+    g2.drawLine(x + 1, y + 4, x + 7, y + 4);
   }
 
   private static void drawDeathItems(Graphics2D g2) {

--- a/src/Game/ReplayQueue.java
+++ b/src/Game/ReplayQueue.java
@@ -48,7 +48,7 @@ public class ReplayQueue {
     try {
       j = new JFileChooser(Settings.REPLAY_BASE_PATH.get("custom"));
     } catch (Exception e) {
-      j = new JFileChooser(Settings.Dir.REPLAY);
+      j = new JFileChooser(System.getProperty("user.home"));
     }
     j.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
     int response = j.showDialog(Game.getInstance().getApplet(), "Select Folder");
@@ -162,7 +162,7 @@ public class ReplayQueue {
               Logger.Info("Please report this as a bug on GitHub if you believe it should work.");
             }
           } catch (Exception ex) {
-            Logger.Error("Error in drop handler!");
+            Logger.Error("Error in replay queue drop handler!");
             ex.printStackTrace();
           }
         }

--- a/src/Game/SoundEffects.java
+++ b/src/Game/SoundEffects.java
@@ -189,6 +189,10 @@ public class SoundEffects {
   }
 
   public static void adjustMudClientSfxVolume() {
+    if (mudClientSourceDataLine == null) {
+      return;
+    }
+
     adjustSfxVolume(mudClientSourceDataLine);
   }
 

--- a/src/Game/XPBar.java
+++ b/src/Game/XPBar.java
@@ -36,9 +36,6 @@ public class XPBar {
   public static int pinnedSkill = -1;
   public static int drawGoalInputState = 0;
 
-  // when replay is initialized, client.username_login will be set to this
-  public static final String excludeUsername = "excludemefromxpbartracking";
-
   public static Dimension bounds = new Dimension(110, 16);
   public static Dimension menuBounds = new Dimension(110, 92);
   public static int xp_bar_x;


### PR DESCRIPTION
This PR includes an assortment of various updates:

Enhancements:
- Saving combat styles per-character, automatically handles player renames, has fallback logic to global "last known style"
- Extraneous combat style packet sending on login to account for the possibility of bad ISAAC parsing
- Reload per-character settings such as the new combat styles and XP goal settings from config.ini on character login, to accommodate multi-clienting
- Ability to drag & drop world ini files over the world settings tab to import them automatically
- New setting for custom screenshot storage directory, with "set" and "open" buttons
- New setting for custom replay storage directory, with "set" and "open" buttons
- Added "set" and "open" buttons for the replay base directory setting
- Button to open the `mods` config directory next to the music enablement button
- Button to open the `bank` config directory at the bottom of the custom bank order settings panel
- Button to open the `speedrunner` config directory at the bottom of the speedrunner mode settings panel
- Button to open the new `logs` config directory at the bottom of the logger settings in the general panel
- Rolling log files with timestamped file names, with a limit of 20 files, stored in a new `logs` config directory
- Darkened the font color for disabled settings elements when using the dark FlatLaf theme, for greater contrast
- Removed now-unnecessary Util.joinAsString method, replaced with native JDK8 function
- Other minor code refactorings and safety checks

Bug fixes:
- The following overlay elements will no longer be drawn when a full-screen interface such as the appearance picker is active:
    - XP bar
    - `+` symbols over settings buttons
    - Inventory count
    - Wiki hbar button
- Fixed the update progress bar rendering logic to work with larger file sizes
- Increased launcher frame width to accommodate bigger JAR file size
- Fixed an XP bar-related crash when creating a new character
- Fixed a late 2020-era regression that broke settings sanitization logic
- Fixed concurrency inconsistencies with XP goal settings when multi-clienting
- Fixed possibility of a mismatch between character XP goal settings when two character names exist that are otherwise identical when spaces are removed
- Fixed edge-case with character replay directory creation when different equivalent login names are used (ex: cOnKeR vs conker)
- Corrected logic that resulted in the double-initialization of the log file as well as the loss of some startup logger output
- Fixed binary detection logic, which previously always returned true regardless of what was passed in