### PR TITLE
Wilderness combat level range display

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -295,6 +295,7 @@ public class ConfigWindow {
   private JCheckBox overlayPanelBuffsCheckbox;
   private JCheckBox overlayPanelKeptItemsCheckbox;
   private JCheckBox overlayPanelKeptItemsWildCheckbox;
+  private JCheckBox overlayPanelWildLevelRangeCheckbox;
   private JCheckBox overlayPanelLastMenuActionCheckbox;
   private JCheckBox overlayPanelMouseTooltipCheckbox;
   private JCheckBox overlayPanelExtendedTooltipCheckbox;
@@ -2387,6 +2388,12 @@ public class ConfigWindow {
     overlayPanelKeptItemsWildCheckbox.setToolTipText(
         "Only displays the \"kept items\" skull when you are in the wilderness");
 
+    overlayPanelWildLevelRangeCheckbox =
+        addCheckbox("Show attackable level range while in the wilderness", overlayPanel);
+    overlayPanelWildLevelRangeCheckbox.setToolTipText(
+        "Displays the attackable combat level range above the wilderness level display");
+    SearchUtils.addSearchMetadata(overlayPanelWildLevelRangeCheckbox, CommonMetadata.PVP.getText());
+
     overlayPanelLastMenuActionCheckbox = addCheckbox("Show last menu action display", overlayPanel);
     overlayPanelLastMenuActionCheckbox.setToolTipText("Toggle last menu action used display");
 
@@ -2592,7 +2599,10 @@ public class ConfigWindow {
             "Show attackable players' names in a separate colour", overlayPanelPvpNamesPanel);
     overlayPanelPvpNamesCheckbox.setToolTipText(
         "Changes the colour of players' names when they are within attacking range in the wilderness");
-    SearchUtils.addSearchMetadata(overlayPanelPvpNamesCheckbox, CommonMetadata.COLOUR.getText());
+    SearchUtils.addSearchMetadata(
+        overlayPanelPvpNamesCheckbox,
+        CommonMetadata.COLOUR.getText(),
+        CommonMetadata.PVP.getText());
 
     overlayPanelPvpNamesColourSubpanel = new JPanel();
     overlayPanelPvpNamesPanel.add(overlayPanelPvpNamesColourSubpanel);
@@ -5008,7 +5018,8 @@ public class ConfigWindow {
     SFX("sfx", "sound effects"),
     FPS("fps", "frames per second"),
     COLOUR("colour", "color"),
-    COLOURS("colours", "colors");
+    COLOURS("colours", "colors"),
+    PVP("pvp", "pk");
 
     public final String text;
 
@@ -6042,6 +6053,8 @@ public class ConfigWindow {
     overlayPanelKeptItemsCheckbox.setSelected(Settings.DEATH_ITEMS.get(Settings.currentProfile));
     overlayPanelKeptItemsWildCheckbox.setSelected(
         Settings.DEATH_ITEMS_WILD.get(Settings.currentProfile));
+    overlayPanelWildLevelRangeCheckbox.setSelected(
+        Settings.SHOW_WILD_RANGE.get(Settings.currentProfile));
     overlayPanelLastMenuActionCheckbox.setSelected(
         Settings.SHOW_LAST_MENU_ACTION.get(Settings.currentProfile));
     overlayPanelMouseTooltipCheckbox.setSelected(
@@ -6515,6 +6528,8 @@ public class ConfigWindow {
     Settings.DEATH_ITEMS.put(Settings.currentProfile, overlayPanelKeptItemsCheckbox.isSelected());
     Settings.DEATH_ITEMS_WILD.put(
         Settings.currentProfile, overlayPanelKeptItemsWildCheckbox.isSelected());
+    Settings.SHOW_WILD_RANGE.put(
+        Settings.currentProfile, overlayPanelWildLevelRangeCheckbox.isSelected());
     Settings.SHOW_LAST_MENU_ACTION.put(
         Settings.currentProfile, overlayPanelLastMenuActionCheckbox.isSelected());
     Settings.SHOW_MOUSE_TOOLTIP.put(

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -41,7 +41,6 @@ import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Properties;
@@ -226,6 +225,7 @@ public class Settings {
   public static HashMap<String, Boolean> SHOW_BUFFS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> DEATH_ITEMS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> DEATH_ITEMS_WILD = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SHOW_WILD_RANGE = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_LAST_MENU_ACTION = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_INVCOUNT = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHOW_INVCOUNT_COLOURS = new HashMap<String, Boolean>();
@@ -1578,6 +1578,15 @@ public class Settings {
     DEATH_ITEMS_WILD.put("all", false);
     DEATH_ITEMS_WILD.put(
         "custom", getPropBoolean(props, "death_items_wild", DEATH_ITEMS_WILD.get("default")));
+
+    SHOW_WILD_RANGE.put("vanilla", false);
+    SHOW_WILD_RANGE.put("vanilla_resizable", false);
+    SHOW_WILD_RANGE.put("lite", false);
+    SHOW_WILD_RANGE.put("default", false);
+    SHOW_WILD_RANGE.put("heavy", true);
+    SHOW_WILD_RANGE.put("all", true);
+    SHOW_WILD_RANGE.put(
+        "custom", getPropBoolean(props, "show_wild_range", SHOW_WILD_RANGE.get("default")));
 
     SHOW_LAST_MENU_ACTION.put("vanilla", false);
     SHOW_LAST_MENU_ACTION.put("vanilla_resizable", false);
@@ -3357,6 +3366,7 @@ public class Settings {
       props.setProperty("show_buffs", Boolean.toString(SHOW_BUFFS.get(preset)));
       props.setProperty("death_items", Boolean.toString(DEATH_ITEMS.get(preset)));
       props.setProperty("death_items_wild", Boolean.toString(DEATH_ITEMS_WILD.get(preset)));
+      props.setProperty("show_wild_range", Boolean.toString(SHOW_WILD_RANGE.get(preset)));
       props.setProperty(
           "show_last_menu_action", Boolean.toString(SHOW_LAST_MENU_ACTION.get(preset)));
       props.setProperty("show_mouse_tooltip", Boolean.toString(SHOW_MOUSE_TOOLTIP.get(preset)));

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2571,9 +2571,19 @@ public class Client {
     }
   }
 
-  // hook to display retro fps on the client, early 2001 style
+  // hook to draw native text on every frame tick
   public static void drawNativeTextHook(Object surfaceInstance) {
     if (surfaceInstance != null) {
+      if (Settings.SHOW_WILD_RANGE.get(Settings.currentProfile) && Client.is_in_wild) {
+        int lowRange = Math.max((Client.getPlayerLevel() - Client.wild_level), 3);
+        int highRange = Math.min(Client.wild_level + Client.getPlayerLevel(), 123);
+        String wildernessRange = "(" + lowRange + " - " + highRange + ")";
+
+        Renderer.drawStringCenter(
+            wildernessRange, Renderer.width - 47, Renderer.height_client - 60, 1, 0xffff00);
+      }
+
+      // display retro fps on the client, early 2001 style
       if (Settings.SHOW_RETRO_FPS.get(Settings.currentProfile)) {
         int offset = 0;
         if (Client.is_in_wild) offset = 70;

--- a/src/Game/SpecialStar.java
+++ b/src/Game/SpecialStar.java
@@ -42,8 +42,9 @@ public class SpecialStar {
     g.dispose();
 
     starGlimmerMask = new short[12][11];
-    try (InputStream inputStream = Launcher.getResource("/assets/starGlimmerMask.dat").openStream();
-         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
+    try (InputStream inputStream =
+            Launcher.getResource("/assets/starGlimmerMask.dat").openStream();
+        BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))) {
       String line;
       int row = 0;
       while ((line = br.readLine()) != null) {


### PR DESCRIPTION
Adds an option to display the attackable level range when in the wilderness above the normal info block, off by default.

![2023_11_03_08_46_PM_RSCPlus (Local; Conker)](https://github.com/RSCPlus/rscplus/assets/16803725/74d55bfa-1703-4d8d-b709-2bfc3bcbd261)

Resolves #183 