### PR TITLE
Fix windows regex parsing for directory paths

### DIFF
--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -2652,7 +2652,7 @@ public class Settings {
 
     if (Util.isWindowsOS()) {
       String windowsPath = new File(path).getAbsolutePath();
-      return (windowsPath + (windowsPath.endsWith("\\") ? "" : "\\")).replaceAll("\\+", "\\");
+      return (windowsPath + (windowsPath.endsWith("\\") ? "" : "\\")).replaceAll("\\\\+", "\\\\");
     }
 
     return (path + (path.endsWith("/") ? "" : "/")).replaceAll("/+", "/");


### PR DESCRIPTION
Dumb mistake on my part -- missed the double-escaping for backslashes