### PR TITLE
Fix sfx initialization when music not enabled

### DIFF
--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -941,18 +941,18 @@ public class Client {
     float delta_time = (float) (nanoTime - last_time) / 1000000000.0f;
     last_time = nanoTime;
 
+    // Set the mudclient volume
+    if (!customSfxVolumeSet) {
+      SoundEffects.adjustMudClientSfxVolume();
+      customSfxVolumeSet = true;
+    }
+
     // Handle area data
     if (Settings.CUSTOM_MUSIC.get(Settings.currentProfile)) {
       if (state == STATE_GAME) {
         AreaDefinition area = getCurrentAreaDefinition();
         MusicPlayer.playTrack(area.music);
       } else if (state == STATE_LOGIN) {
-        // Set the client volume
-        if (!customSfxVolumeSet) {
-          SoundEffects.adjustMudClientSfxVolume();
-          customSfxVolumeSet = true;
-        }
-
         MusicPlayer.playTrack(loginTrack);
       }
     }


### PR DESCRIPTION
Fixes a mistake I made in a previous commit wherein I accidentally put the SFX volume adjustment logic inside of the "is music enabled" conditional.