### PR TITLE
Suppress login/out messages, skippable message hook

### DIFF
--- a/src/Client/ConfigWindow.java
+++ b/src/Client/ConfigWindow.java
@@ -251,6 +251,7 @@ public class ConfigWindow {
   private JSlider generalPanelFoVSlider;
   private JCheckBox generalPanelCustomCursorCheckbox;
   private JCheckBox generalPanelCtrlScrollChatCheckbox;
+  private JCheckBox generalPanelSuppressLoginLogoutMessagesCheckbox;
   private JCheckBox generalPanelShiftScrollCameraRotationCheckbox;
   private JSlider generalPanelTrackpadRotationSlider;
   private JCheckBox generalPanelCustomRandomChatColourCheckbox;
@@ -1547,6 +1548,11 @@ public class ConfigWindow {
         addCheckbox("Hold ctrl to scroll through chat history from anywhere", generalPanel);
     generalPanelCtrlScrollChatCheckbox.setToolTipText(
         "Holding CTRL allows you to scroll through the currently-selected chat history from anywhere");
+
+    generalPanelSuppressLoginLogoutMessagesCheckbox =
+        addCheckbox("Suppress friend login / logout messages", generalPanel);
+    generalPanelSuppressLoginLogoutMessagesCheckbox.setToolTipText(
+        "Private messages indicating when a friend logs in or out will no longer be output");
 
     generalPanelShiftScrollCameraRotationCheckbox =
         addCheckbox("Enable camera rotation with compatible trackpads", generalPanel);
@@ -4138,6 +4144,12 @@ public class ConfigWindow {
         "toggle_ctrl_scroll",
         KeyModifier.ALT,
         KeyEvent.VK_H);
+    addKeybindSet(
+        keybindContainerPanel,
+        "Toggle friend login/logout messages",
+        "toggle_login_logout_messages",
+        KeyModifier.ALT,
+        KeyEvent.VK_L);
     addKeybindCategory(keybindContainerPanel, "Overlays");
     addKeybindSet(
         keybindContainerPanel,
@@ -4487,10 +4499,9 @@ public class ConfigWindow {
         "Buttons you can click on to increase speed, decrease speed, restart, play/pause");
 
     replayPanelHidePrivateMessagesCheckbox =
-        addCheckbox(
-            "Prevent private messages from being output to the console during replay", replayPanel);
+        addCheckbox("Prevent private messages from being output during replay", replayPanel);
     replayPanelHidePrivateMessagesCheckbox.setToolTipText(
-        "Message types 1, 2, and 5 will not be output to the console when this is selected"); // TODO: possibly don't show in client either
+        "Message types 1, 2, and 5 will not be output when this is selected");
 
     replayPanelTriggerAlertsReplayCheckbox =
         addCheckbox("Prevent system alerts from triggering during replay", replayPanel);
@@ -5980,6 +5991,8 @@ public class ConfigWindow {
         Settings.SOFTWARE_CURSOR.get(Settings.currentProfile));
     generalPanelCtrlScrollChatCheckbox.setSelected(
         Settings.CTRL_SCROLL_CHAT.get(Settings.currentProfile));
+    generalPanelSuppressLoginLogoutMessagesCheckbox.setSelected(
+        Settings.SUPPRESS_LOG_IN_OUT_MSGS.get(Settings.currentProfile));
     generalPanelShiftScrollCameraRotationCheckbox.setSelected(
         Settings.SHIFT_SCROLL_CAMERA_ROTATION.get(Settings.currentProfile));
     generalPanelTrackpadRotationSlider.setValue(
@@ -6488,6 +6501,8 @@ public class ConfigWindow {
         Settings.currentProfile, generalPanelCustomCursorCheckbox.isSelected());
     Settings.CTRL_SCROLL_CHAT.put(
         Settings.currentProfile, generalPanelCtrlScrollChatCheckbox.isSelected());
+    Settings.SUPPRESS_LOG_IN_OUT_MSGS.put(
+        Settings.currentProfile, generalPanelSuppressLoginLogoutMessagesCheckbox.isSelected());
     Settings.SHIFT_SCROLL_CAMERA_ROTATION.put(
         Settings.currentProfile, generalPanelShiftScrollCameraRotationCheckbox.isSelected());
     Settings.TRACKPAD_ROTATION_SENSITIVITY.put(

--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -2874,6 +2874,8 @@ public class JClassPatcher {
               "(ZLjava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;)V")) {
         AbstractInsnNode first = methodNode.instructions.getFirst();
 
+        LabelNode continueLabel = new LabelNode();
+
         methodNode.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 7));
         methodNode.instructions.insertBefore(first, new VarInsnNode(Opcodes.ALOAD, 4));
         methodNode.instructions.insertBefore(first, new VarInsnNode(Opcodes.ILOAD, 5));
@@ -2884,7 +2886,10 @@ public class JClassPatcher {
                 Opcodes.INVOKESTATIC,
                 "Game/Client",
                 "messageHook",
-                "(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)V"));
+                "(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;)Z"));
+        methodNode.instructions.insertBefore(first, new JumpInsnNode(Opcodes.IFGT, continueLabel));
+        methodNode.instructions.insertBefore(first, new InsnNode(Opcodes.RETURN));
+        methodNode.instructions.insertBefore(first, continueLabel);
 
         // Replay seeking don't show messages hook
         // LabelNode label = new LabelNode();

--- a/src/Client/Settings.java
+++ b/src/Client/Settings.java
@@ -134,6 +134,7 @@ public class Settings {
   public static HashMap<String, Integer> FPS_LIMIT = new HashMap<String, Integer>();
   public static HashMap<String, Boolean> SOFTWARE_CURSOR = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> CTRL_SCROLL_CHAT = new HashMap<String, Boolean>();
+  public static HashMap<String, Boolean> SUPPRESS_LOG_IN_OUT_MSGS = new HashMap<String, Boolean>();
   public static HashMap<String, Boolean> SHIFT_SCROLL_CAMERA_ROTATION =
       new HashMap<String, Boolean>();
   public static HashMap<String, Integer> TRACKPAD_ROTATION_SENSITIVITY =
@@ -865,6 +866,16 @@ public class Settings {
     CTRL_SCROLL_CHAT.put("all", true);
     CTRL_SCROLL_CHAT.put(
         "custom", getPropBoolean(props, "ctrl_scroll_chat", CTRL_SCROLL_CHAT.get("default")));
+
+    SUPPRESS_LOG_IN_OUT_MSGS.put("vanilla", false);
+    SUPPRESS_LOG_IN_OUT_MSGS.put("vanilla_resizable", false);
+    SUPPRESS_LOG_IN_OUT_MSGS.put("lite", false);
+    SUPPRESS_LOG_IN_OUT_MSGS.put("default", false);
+    SUPPRESS_LOG_IN_OUT_MSGS.put("heavy", false);
+    SUPPRESS_LOG_IN_OUT_MSGS.put("all", true);
+    SUPPRESS_LOG_IN_OUT_MSGS.put(
+        "custom",
+        getPropBoolean(props, "suppress_log_in_out_msg", SUPPRESS_LOG_IN_OUT_MSGS.get("default")));
 
     SHIFT_SCROLL_CAMERA_ROTATION.put("vanilla", false);
     SHIFT_SCROLL_CAMERA_ROTATION.put("vanilla_resizable", false);
@@ -3267,6 +3278,8 @@ public class Settings {
       props.setProperty("software_cursor", Boolean.toString(SOFTWARE_CURSOR.get(preset)));
       props.setProperty("ctrl_scroll_chat", Boolean.toString(CTRL_SCROLL_CHAT.get(preset)));
       props.setProperty(
+          "suppress_log_in_out_msg", Boolean.toString(SUPPRESS_LOG_IN_OUT_MSGS.get(preset)));
+      props.setProperty(
           "shift_scroll_camera_rotation",
           Boolean.toString(SHIFT_SCROLL_CAMERA_ROTATION.get(preset)));
       props.setProperty(
@@ -4228,6 +4241,20 @@ public class Settings {
     save();
   }
 
+  public static void toggleSuppressLogInOutMessages() {
+    SUPPRESS_LOG_IN_OUT_MSGS.put(currentProfile, !SUPPRESS_LOG_IN_OUT_MSGS.get(currentProfile));
+
+    if (SUPPRESS_LOG_IN_OUT_MSGS.get(currentProfile)) {
+      Client.displayMessage(
+          "@cya@Friend login / logout messages will no longer be shown", Client.CHAT_NONE);
+    } else {
+      Client.displayMessage(
+          "@cya@Friend login / logout messages will now be shown", Client.CHAT_NONE);
+    }
+
+    save();
+  }
+
   public static void toggleColorTerminal() {
     COLORIZE_CONSOLE_TEXT.put(currentProfile, !COLORIZE_CONSOLE_TEXT.get(currentProfile));
 
@@ -4552,6 +4579,9 @@ public class Settings {
         return true;
       case "toggle_ctrl_scroll":
         Settings.toggleCtrlScroll();
+        return true;
+      case "toggle_login_logout_messages":
+        Settings.toggleSuppressLogInOutMessages();
         return true;
       case "toggle_colorize":
         Settings.toggleColorTerminal();


### PR DESCRIPTION
* Enhanced the game message hook with the ability to prevent client message printing
* New setting to suppress login/logout messages, off by default, bound to `ALT-L`
* Updated the setting which prevents PM output during replays to no longer print messages to the game client
