### PR TITLE
Harden bank UI drawing hook

### DIFF
--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -1738,6 +1738,25 @@ public class JClassPatcher {
             }
           }
         }
+
+        // reset bank drawn flag
+        insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+
+          if (insnNode.getOpcode() == Opcodes.PUTFIELD
+              && ((FieldInsnNode) insnNode).owner.equals("client")
+              && ((FieldInsnNode) insnNode).name.equals("Fe")
+              && ((FieldInsnNode) insnNode).desc.equals("Z")) {
+            insnNode = insnNode.getNext();
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "bank_interface_drawn", "Z"));
+
+            break;
+          }
+        }
       }
 
       if (methodNode.name.equals("a")
@@ -4752,6 +4771,54 @@ public class JClassPatcher {
                 new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "ba", "a", "(II[BI[B)V", false));
 
             methodNode.instructions.insertBefore(targetNode, label);
+
+            break;
+          }
+        }
+      }
+
+      // draw bank interface
+      if (methodNode.name.equals("r") && methodNode.desc.equals("(I)V")) {
+        Iterator<AbstractInsnNode> insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+
+          // reset bank drawn flag
+          if (insnNode.getOpcode() == Opcodes.PUTFIELD
+              && ((FieldInsnNode) insnNode).owner.equals("client")
+              && ((FieldInsnNode) insnNode).name.equals("Fe")
+              && ((FieldInsnNode) insnNode).desc.equals("Z")) {
+            insnNode = insnNode.getNext();
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_0));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "bank_interface_drawn", "Z"));
+
+            break;
+          }
+        }
+
+        // set bank drawn flag
+        insnNodeList = methodNode.instructions.iterator();
+        while (insnNodeList.hasNext()) {
+          AbstractInsnNode insnNode = insnNodeList.next();
+          if (insnNode.getOpcode() == Opcodes.INVOKEVIRTUAL
+              && ((MethodInsnNode) insnNode).owner.equals("ba")
+              && ((MethodInsnNode) insnNode).name.equals("b")
+              && ((MethodInsnNode) insnNode).desc.equals("(IIIIB)V")) {
+            insnNode = insnNodeList.next();
+
+            LabelNode skipLabel = new LabelNode();
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new FieldInsnNode(Opcodes.GETSTATIC, "Game/Client", "bank_interface_drawn", "Z"));
+            methodNode.instructions.insertBefore(
+                insnNode, new JumpInsnNode(Opcodes.IFGT, skipLabel));
+            methodNode.instructions.insertBefore(insnNode, new InsnNode(Opcodes.ICONST_1));
+            methodNode.instructions.insertBefore(
+                insnNode,
+                new FieldInsnNode(Opcodes.PUTSTATIC, "Game/Client", "bank_interface_drawn", "Z"));
+            methodNode.instructions.insertBefore(insnNode, skipLabel);
 
             break;
           }

--- a/src/Game/Bank.java
+++ b/src/Game/Bank.java
@@ -704,7 +704,7 @@ public class Bank {
 
   // Draws extra buttons on the side of the bank to control filtering
   public static void drawBankAugmentations(Graphics2D g2, BufferedMouseClick bufferedMouseClick) {
-    if (Client.show_bank) {
+    if (Client.bank_interface_drawn) {
       if (Settings.SORT_FILTER_BANK.get(Settings.currentProfile)) {
         // existing bank interface dimensions
         int bankWidth = 408;

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -154,6 +154,7 @@ public class Client {
   public static int combat_timer;
   public static boolean isGameLoaded;
   public static boolean show_bank;
+  public static boolean bank_interface_drawn;
   public static boolean show_duel;
   public static boolean show_duelconfirm;
   public static int show_friends;
@@ -1509,6 +1510,9 @@ public class Client {
       // sleep exit packet, restore whatever was in pm
       pm_enteredText = pm_enteredTextCopy;
       pm_enteredTextCopy = "";
+    } else if (opcode == 203) {
+      // bank close packet
+      bank_interface_drawn = false;
     }
 
     if (Bank.processPacket(opcode, psize)) {


### PR DESCRIPTION
Changed the condition for drawing the custom bank UI to happen only after the bank interface has actually been drawn.

This will hopefully prevent the situation wherein it gets drawn once the client thinks the interface is open, but hasn't actually drawn the UI yet, as shown here:

![KJfqLG5](https://github.com/RSCPlus/rscplus/assets/16803725/193f61f0-b15c-4c64-994f-9eed686807bf)
