### PR TITLE
Fix item patching when switching server types

### DIFF
--- a/src/Client/JClassPatcher.java
+++ b/src/Client/JClassPatcher.java
@@ -395,6 +395,7 @@ public class JClassPatcher {
           "[Ljava/lang/String;");
       hookStaticVariable(methodNode, "kb", "b", "[I", "Game/Item", "item_price", "[I");
       hookStaticVariable(methodNode, "fa", "e", "[I", "Game/Item", "item_stackable", "[I");
+      hookStaticVariable(methodNode, "ka", "c", "[I", "Game/Item", "item_members", "[I");
 
       hookConditionalClassVariable(
           methodNode,

--- a/src/Game/Client.java
+++ b/src/Game/Client.java
@@ -2352,6 +2352,10 @@ public class Client {
         // force re-render of game world terrain
         lastHeightOffset = (planeIndex + 1) % 2;
       }
+
+      // Re-patch item names
+      ItemNamePatch.reinit();
+      Item.repatchItemNames();
     } catch (Exception e) {
     }
   }

--- a/src/Game/Item.java
+++ b/src/Game/Item.java
@@ -34,9 +34,10 @@ public class Item {
   public static String[] item_commands;
   public static int[] item_price;
   public static int[] item_stackable;
+  public static int[] item_members;
   public static List<Item> cool_items = new ArrayList<>();
 
-  private static int name_patch_last = 0;
+  private static int name_patch_last = -1;
 
   public static int[] groundItemX;
   public static int[] groundItemY;
@@ -87,7 +88,21 @@ public class Item {
         item_name = ItemNamePatch.item_name_patch3.clone();
         break;
     }
+
+    if (!Client.members) {
+      for (int i = 0; i < item_members.length; i++) {
+        if (item_members[i] == 1) {
+          item_name[i] = "Members object";
+        }
+      }
+    }
+
     name_patch_last = namePatchType;
+  }
+
+  public static void repatchItemNames() {
+    name_patch_last = -1;
+    patchItemNames();
   }
 
   /**

--- a/src/Game/ItemNamePatch.java
+++ b/src/Game/ItemNamePatch.java
@@ -1000,4 +1000,9 @@ public class ItemNamePatch {
 
     initialized = true;
   }
+
+  public static void reinit() {
+    initialized = false;
+    init();
+  }
 }


### PR DESCRIPTION
The item name patching needed to be re-initialized and re-run when switching server types, otherwise the arrays are stuck to whatever it was on client launch.